### PR TITLE
Added SpriteLayerAttribute.

### DIFF
--- a/Attributes/SpriteLayerAttribute.cs
+++ b/Attributes/SpriteLayerAttribute.cs
@@ -1,0 +1,117 @@
+﻿using UnityEngine;
+using UnityEditor;
+
+public class SpriteLayerAttribute : PropertyAttribute
+{
+}
+
+#region Drawer
+
+[CustomPropertyDrawer(typeof(SpriteLayerAttribute))]
+public class SpriteLayerAttributeDrawer : PropertyDrawer
+{
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        if (property.propertyType != SerializedPropertyType.Integer)
+        {
+            Debug.LogWarning(string.Format("Property <color=brown>{0}</color> in object <color=brown>{1}</color> is of wrong type. Expected: Int", property.name, GetTargettedObjectFromProperty(property)));
+        } else
+        {
+            var spriteLayerNames = GetSpriteLayerNames();
+
+            if (!ArrayIsNullOrEmpty(spriteLayerNames))
+            {
+                HandleSpriteLayerSelectionUI(position, property, label, spriteLayerNames);
+            } else
+            {
+                /// Shouldn't occur since Default layer exists all the time.
+                Debug.LogWarning(string.Format("Property <color=brown>{0}</color> in object <color=brown>{1}</color>.Reason: There is no sprite layers to select from!", property.name, property.name));
+            }
+        }
+    }
+
+    private void HandleSpriteLayerSelectionUI(Rect position, SerializedProperty property, GUIContent label, string[] spriteLayerNames)
+    {
+        EditorGUI.BeginProperty(position, label, property);
+
+        // To show which sprite layer is currently selected.
+        int currentSpriteLayerIndex;
+        bool layerFound = TryGetSpriteLayerIndexFromProperty(out currentSpriteLayerIndex, spriteLayerNames, property);
+
+        if (!layerFound)
+        {
+            // Set to default layer. (Previous layer was removed)
+            Debug.Log(string.Format("Property <color=brown>{0}</color> in object <color=brown>{1}</color> is set to the default layer. Reason: previously selected layer was removed.", property.name, GetTargettedObjectFromProperty(property)));
+            property.intValue = 0;
+            currentSpriteLayerIndex = 0;
+        }
+
+        int selectedSpriteLayerIndex = EditorGUI.Popup(position, label.text, currentSpriteLayerIndex, spriteLayerNames);
+
+        // Change property value if user selects a new sprite layer.
+        if (selectedSpriteLayerIndex != currentSpriteLayerIndex)
+        {
+            property.intValue = SortingLayer.NameToID(spriteLayerNames[selectedSpriteLayerIndex]);
+        }
+
+        EditorGUI.EndProperty();
+    }
+
+    #region Util
+
+    private Object GetTargettedObjectFromProperty(SerializedProperty property)
+    {
+        return property.serializedObject.targetObject;
+    }
+
+    private bool TryGetSpriteLayerIndexFromProperty(out int index, string[] spriteLayerNames, SerializedProperty property)
+    {
+        // To keep the property's value consistent, after the layers have been sorted around.
+        string layerName = SortingLayer.IDToName(property.intValue);
+
+        // Return the index where on it matches.
+        for (int i = 0; i < spriteLayerNames.Length; ++i)
+        {
+            if (spriteLayerNames[i].Equals(layerName))
+            {
+                index = i;
+                return true;
+            }
+        }
+
+        // The current layer was removed.
+        index = -1;
+        return false;
+    }
+
+    private bool ArrayIsNullOrEmpty<T>(T[] array)
+    {
+        bool isNullOrEmpty = false;
+
+        if (array == null)
+        {
+            isNullOrEmpty = true;
+        } else if (array.Length < 1)
+        {
+            isNullOrEmpty = true;
+        }
+
+        return isNullOrEmpty;
+    }
+
+    private string[] GetSpriteLayerNames()
+    {
+        string[] result = new string[SortingLayer.layers.Length];
+
+        for (int i = 0; i < result.Length; ++i)
+        {
+            result[i] = SortingLayer.layers[i].name;
+        }
+
+        return result;
+    }
+    #endregion
+}
+
+
+#endregion

--- a/Attributes/SpriteLayerAttribute.cs.meta
+++ b/Attributes/SpriteLayerAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f05661da7d39cf418051ccfb13eb5a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
An Attribute that creates a drop-down box where you can select sorting layer for sprites.

**Side note:**
In `HandleSpriteLayerSelectionUI()` function for the drawer, there is a `Debug.Log` which warns the user that the Default sprite has been set, mainly due to the selected sprite-layer being removed.<br>
Could set it to `Debug.LogWarning` instead if you wish to.
(This is in line 44 of the committed attribute file)