### PR TITLE
Added EditorInvokable Attribute

### DIFF
--- a/Attributes/EditorInvokableAttribute.cs
+++ b/Attributes/EditorInvokableAttribute.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+
+using System.Reflection;
+using UnityEngine;
+
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace MyBox
+{
+    [AttributeUsage(AttributeTargets.Method)]
+    public class EditorInvokableAttribute : PropertyAttribute
+    {
+    }
+}
+
+#if UNITY_EDITOR
+namespace MyBox.Internal
+{
+    [CustomEditor(typeof(MonoBehaviour), true)]
+    public class EditorInvokableAttributeEditor : Editor
+    {
+        public override void OnInspectorGUI()
+        {
+            base.OnInspectorGUI();
+
+            var monoBehaviourTarget = target as MonoBehaviour;
+
+            var methods = GetAllEditorButtonAttributedMembersFromTargetMonoBehaviour(monoBehaviourTarget);
+
+            foreach (MemberInfo memberInfo in methods)
+            {
+                InvokeMethodIfUserInputButton(memberInfo, monoBehaviourTarget);
+            }
+        }
+
+        private void InvokeMethodIfUserInputButton(MemberInfo memberInfo, MonoBehaviour target)
+        {
+            if (GUILayout.Button(memberInfo.Name))
+            {
+                InvokeIfMemberIsMethod(memberInfo);
+            }
+        }
+
+        private void InvokeIfMemberIsMethod(MemberInfo member)
+        {
+
+            MethodInfo method = member as MethodInfo;
+            if (method != null)
+            {
+                InvokeMethodIfNonParameterized(method);
+            } else
+            {
+                // Liekly to not occur due to the AttributeUsage applied to the attribute.
+                Debug.LogWarning(string.Format("Property <color=brown>{0}</color>.Reason: Member is not a method but has EditorButtonAttribute!", member.Name));
+            }
+        }
+
+        private void InvokeMethodIfNonParameterized(MethodInfo method)
+        {
+            if (method.GetParameters().Length > 0)
+            {
+                Debug.LogWarning(string.Format("Method <color=brown>{0}</color>.Reason: Methods with parameters is not supported by EditorButtonAttribute!", method.Name));
+            } else
+            {
+                var returnObj = method.Invoke(target, null);
+
+                if (returnObj != null)
+                {
+                    Debug.Log(string.Format("Method '{0}' returned: {1}", method.Name, returnObj.ToString()));
+                }
+            }
+        }
+
+        #region Util
+        private IEnumerable<MemberInfo> GetAllEditorButtonAttributedMembersFromTargetMonoBehaviour(MonoBehaviour target)
+        {
+            return target.GetType()
+                .GetMembers(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+                .Where(MemberInfoHasEditorInvokableAttribute);
+        }
+
+        private bool MemberInfoHasEditorInvokableAttribute(MemberInfo memberInfo)
+        {
+            return Attribute.IsDefined(memberInfo, typeof(EditorInvokableAttribute));
+        }
+        #endregion
+    }
+}
+#endif

--- a/Attributes/EditorInvokableAttribute.cs.meta
+++ b/Attributes/EditorInvokableAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e96e2e6d8d1626c4abf4c413bc489af0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
`EditorInvokableAttribute` Allows invoking of method through the inspector. <br>(Similar to the button attribute)

```
    public int aVeryUsefulNumber;

    [MyBox.EditorInvokable]
    public void TestingStuff() {
        Debug.Log("Fire");
        aVeryUsefulNumber = Random.Range(0, 10);
    }

    [MyBox.EditorInvokable]
    public bool BigBool() {
        Debug.Log("stuff");

        // Will auto-log it's return value (to string) in inspector.
        return true;
    }
```

[GIF](https://i.imgur.com/rOWwTpJ.gifv) of code in work
(https://i.imgur.com/rOWwTpJ.gifv)

Though honestly, the only notable difference from the `Button` attribute is the fact that the attribute can be directly applied to the desired methods, rather than a field.
It also auto-logs any values returned.