### PR TITLE
[Bugfix] Update SerializedProperty extension method "GetParent"

### DIFF
--- a/Extensions/EditorExtensions/MyGUI.cs
+++ b/Extensions/EditorExtensions/MyGUI.cs
@@ -1,17 +1,15 @@
 ﻿#if UNITY_EDITOR
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using UnityEngine;
 using UnityEditor;
 using Object = UnityEngine.Object;
 
 namespace MyBox.EditorTools
 {
-	public static class MyGUI
+    public static class MyGUI
 	{
 		#region Colors
 
@@ -315,66 +313,6 @@ namespace MyBox.EditorTools
 			}
 
 			GUI.enabled = guiState;
-		}
-
-		#endregion
-
-
-		#region SerializedProperty Get Parent
-
-		// Found here http://answers.unity.com/answers/425602/view.html
-		/// <summary>
-		/// Get parent object of SerializedProperty
-		/// </summary>
-		public static object GetParent(this SerializedProperty prop)
-		{
-			var path = prop.propertyPath.Replace(".Array.data[", "[");
-			object obj = prop.serializedObject.targetObject;
-			var elements = path.Split('.');
-			foreach (var element in elements.Take(elements.Length - 1))
-			{
-				if (element.Contains("["))
-				{
-					var elementName = element.Substring(0, element.IndexOf("[", StringComparison.Ordinal));
-					var index = Convert.ToInt32(element.Substring(element.IndexOf("[", StringComparison.Ordinal)).Replace("[", "").Replace("]", ""));
-					obj = GetValueAt(obj, elementName, index);
-				}
-				else
-				{
-					obj = GetValue(obj, element);
-				}
-			}
-
-			return obj;
-		}
-
-		private static object GetValue(object source, string name)
-		{
-			if (source == null)
-				return null;
-			var type = source.GetType();
-			var f = type.GetField(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
-			if (f == null)
-			{
-				var p = type.GetProperty(name,
-					BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-				if (p == null)
-					return null;
-				return p.GetValue(source, null);
-			}
-
-			return f.GetValue(source);
-		}
-
-		private static object GetValueAt(object source, string name, int index)
-		{
-			var enumerable = GetValue(source, name) as IEnumerable;
-			if (enumerable == null) return null;
-
-			var enm = enumerable.GetEnumerator();
-			while (index-- >= 0)
-				enm.MoveNext();
-			return enm.Current;
 		}
 
 		#endregion

--- a/Extensions/EditorExtensions/MySerializedProperty.cs
+++ b/Extensions/EditorExtensions/MySerializedProperty.cs
@@ -1,5 +1,6 @@
 #if UNITY_EDITOR
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -38,7 +39,6 @@ namespace MyBox.EditorTools
 			for (int i = 0; i < property.arraySize; i++)
 				yield return property.GetArrayElementAtIndex(i);
 		}
-
 
 		/// <summary>
 		/// Replace array contents of SerializedProperty with another array 
@@ -119,6 +119,76 @@ namespace MyBox.EditorTools
 			if (fieldInfo == null) return false;
 			return Attribute.IsDefined(fieldInfo, typeof(T));
 		}
-	}
+
+        #region SerializedProperty Get Parent
+
+        // Found here http://answers.unity.com/answers/425602/view.html
+        // Update here https://gist.github.com/AdrienVR/1548a145c039d2fddf030ebc22f915de to support inherited private members.
+        /// <summary>
+        /// Get parent object of SerializedProperty
+        /// </summary>
+        public static object GetParent(this SerializedProperty prop)
+        {
+            var path = prop.propertyPath.Replace(".Array.data[", "[");
+            object obj = prop.serializedObject.targetObject;
+            var elements = path.Split('.');
+            foreach (var element in elements.Take(elements.Length - 1))
+            {
+                if (element.Contains("["))
+                {
+                    var elementName = element.Substring(0, element.IndexOf("[", StringComparison.Ordinal));
+                    var index = Convert.ToInt32(element.Substring(element.IndexOf("[", StringComparison.Ordinal)).Replace("[", "").Replace("]", ""));
+                    obj = GetValueAt(obj, elementName, index);
+                }
+                else
+                {
+                    obj = GetValue(obj, element);
+                }
+            }
+
+            return obj;
+        }
+
+        private static object GetValue(object source, string name)
+        {
+            if (source == null)
+                return null;
+
+            foreach (var type in GetHierarchyTypes(source.GetType()))
+            {
+                var f = type.GetField(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance);
+                if (f != null)
+                    return f.GetValue(source);
+
+                var p = type.GetProperty(name, BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
+                if (p != null)
+                    return p.GetValue(source, null);
+            }
+            return null;
+
+            IEnumerable<Type> GetHierarchyTypes(Type sourceType)
+            {
+                yield return sourceType;
+                while (sourceType.BaseType != null)
+                {
+                    yield return sourceType.BaseType;
+                    sourceType = sourceType.BaseType;
+                }
+            }
+        }
+
+        private static object GetValueAt(object source, string name, int index)
+        {
+            var enumerable = GetValue(source, name) as IEnumerable;
+            if (enumerable == null) return null;
+
+            var enm = enumerable.GetEnumerator();
+            while (index-- >= 0)
+                enm.MoveNext();
+            return enm.Current;
+        }
+
+        #endregion
+    }
 }
 #endif


### PR DESCRIPTION
[Bugfix] Update SerializedProperty extension method "GetParent" to support inherited private members. Move it into MySerializedProperty.cs

In my case it was not working for [SerializedDictionary](https://github.com/azixMcAze/Unity-SerializableDictionary), my custom property drawer was associated to a property inside a dictionary value and the dictionary values are serialized in a private field of the "SerializableDictionaryBase" base class.

So I browse through all the base types to look for the member and it works.

And as it seems you like refactoring, I moved the method into MySerializedProperty.cs as I thought I was the right place for it.