### PR TITLE
ConditionalField can now compare against multiple values

### DIFF
--- a/Attributes/ConditionalFieldAttribute.cs
+++ b/Attributes/ConditionalFieldAttribute.cs
@@ -38,7 +38,6 @@ namespace MyBox {
 
 
             if (_compareValues != null) {
-                // TODO: Refactor
                 if (!_inverse) {
                     return PropertyValueEqualsAnyValuesToCompare(asString);
                 } else {

--- a/Attributes/ConditionalFieldAttribute.cs
+++ b/Attributes/ConditionalFieldAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -6,168 +6,173 @@ using UnityEngine;
 using UnityEditor;
 #endif
 
-namespace MyBox
-{
-	[AttributeUsage(AttributeTargets.Field)]
-	public class ConditionalFieldAttribute : PropertyAttribute
-	{
-		private readonly string _fieldToCheck;
-		private readonly object _compareValue;
-		private readonly bool _inverse;
-		
-		public ConditionalFieldAttribute(string fieldToCheck, object compareValue = null, bool inverse = false)
-		{
-			_fieldToCheck = fieldToCheck;
-			_compareValue = compareValue;
-			_inverse = inverse;
-		}
+namespace MyBox {
+    [AttributeUsage(AttributeTargets.Field)]
+    public class ConditionalFieldAttribute : PropertyAttribute {
+        private readonly string _fieldToCheck;
+        private readonly object[] _compareValues;
+        private readonly bool _inverse;
+
+        public ConditionalFieldAttribute(string fieldToCheck, bool inverse = false, params object[] compareValues) {
+            _fieldToCheck = fieldToCheck;
+            _compareValues = compareValues;
+            _inverse = inverse;
+        }
 
 #if UNITY_EDITOR
-		public bool CheckBehaviourPropertyVisible(MonoBehaviour behaviour, string propertyName)
-		{
-			if (string.IsNullOrEmpty(_fieldToCheck)) return true;
+        public bool CheckBehaviourPropertyVisible(MonoBehaviour behaviour, string propertyName) {
+            if (string.IsNullOrEmpty(_fieldToCheck)) return true;
 
-			var so = new SerializedObject(behaviour);
-			var property = so.FindProperty(propertyName);
+            var so = new SerializedObject(behaviour);
+            var property = so.FindProperty(propertyName);
 
-			return CheckPropertyVisible(property);
-		}
-
-
-		public bool CheckPropertyVisible(SerializedProperty property)
-		{
-			var conditionProperty = FindRelativeProperty(property, _fieldToCheck);
-			if (conditionProperty == null) return true;
-			
-			string asString = AsStringValue(conditionProperty).ToUpper();
-
-			
-			if (_compareValue != null)
-			{
-				bool compareValueMatch = _compareValue.ToString().ToUpper() == asString;
-				return compareValueMatch ? !_inverse : _inverse;
-			}
+            return CheckPropertyVisible(property);
+        }
 
 
-			bool someValueAssigned = asString != "FALSE" && asString != "0" && asString != "NULL";
-			if (someValueAssigned) return !_inverse;
+        public bool CheckPropertyVisible(SerializedProperty property) {
+            var conditionProperty = FindRelativeProperty(property, _fieldToCheck);
+            if (conditionProperty == null) return true;
 
-			return _inverse;
-		}
-
-		private SerializedProperty FindRelativeProperty(SerializedProperty property, string toGet)
-		{
-			if (property.depth == 0) return property.serializedObject.FindProperty(toGet);
-
-			var path = property.propertyPath.Replace(".Array.data[", "[");
-			var elements = path.Split('.');
-
-			var nestedProperty = NestedPropertyOrigin(property, elements);
-
-			// if nested property is null = we hit an array property
-			if (nestedProperty == null)
-			{
-				var cleanPath = path.Substring(0, path.IndexOf('['));
-				var arrayProp = property.serializedObject.FindProperty(cleanPath);
-				if (_warningsPool.Contains(arrayProp.exposedReferenceValue)) return null;
-				var target = arrayProp.serializedObject.targetObject;
-				var who = string.Format("Property <color=brown>{0}</color> in object <color=brown>{1}</color> caused: ", arrayProp.name,
-					target.name);
-
-				Debug.LogWarning(who + "Array fields is not supported by [ConditionalFieldAttribute]", target);
-				_warningsPool.Add(arrayProp.exposedReferenceValue);
-				return null;
-			}
-
-			return nestedProperty.FindPropertyRelative(toGet);
-		}
-
-		// For [Serialized] types with [Conditional] fields
-		private SerializedProperty NestedPropertyOrigin(SerializedProperty property, string[] elements)
-		{
-			SerializedProperty parent = null;
-
-			for (int i = 0; i < elements.Length - 1; i++)
-			{
-				var element = elements[i];
-				int index = -1;
-				if (element.Contains("["))
-				{
-					index = Convert.ToInt32(element.Substring(element.IndexOf("[", StringComparison.Ordinal))
-						.Replace("[", "").Replace("]", ""));
-					element = element.Substring(0, element.IndexOf("[", StringComparison.Ordinal));
-				}
-
-				parent = i == 0
-					? property.serializedObject.FindProperty(element)
-					: parent.FindPropertyRelative(element);
-
-				if (index >= 0) parent = parent.GetArrayElementAtIndex(index);
-			}
-
-			return parent;
-		}
+            string asString = AsStringValue(conditionProperty).ToUpper();
 
 
-		private string AsStringValue(SerializedProperty prop)
-		{
-			switch (prop.propertyType)
-			{
-				case SerializedPropertyType.String:
-					return prop.stringValue;
+            if (_compareValues != null) {
+                // TODO: Refactor
+                if (!_inverse) {
+                    return PropertyValueEqualsAnyValuesToCompare(asString);
+                } else {
+                    return !PropertyValueEqualsAnyValuesToCompare(asString);
+                }
+            }
 
-				case SerializedPropertyType.Character:
-				case SerializedPropertyType.Integer:
-					if (prop.type == "char") return Convert.ToChar(prop.intValue).ToString();
-					return prop.intValue.ToString();
 
-				case SerializedPropertyType.ObjectReference:
-					return prop.objectReferenceValue != null ? prop.objectReferenceValue.ToString() : "null";
+            bool someValueAssigned = asString != "FALSE" && asString != "0" && asString != "NULL";
+            if (someValueAssigned) return !_inverse;
 
-				case SerializedPropertyType.Boolean:
-					return prop.boolValue.ToString();
+            return _inverse;
+        }
 
-				case SerializedPropertyType.Enum:
-					return prop.enumNames[prop.enumValueIndex];
+        /// <summary>
+        /// True if the property value matches any of the values in '_compareValues'
+        /// </summary>
+        /// <param name="propertyValueAsString"></param>
+        /// <returns></returns>
+        private bool PropertyValueEqualsAnyValuesToCompare(string propertyValueAsString) {
+            foreach (object valueToCompare in _compareValues) {
+                bool valueMatches = valueToCompare.ToString().ToUpper() == propertyValueAsString;
 
-				default:
-					return string.Empty;
-			}
-		}
+                if (valueMatches) {
+                    // One of the value is equals to the property value.
+                    return true;
+                }
+            }
 
-		//This pool is used to prevent spamming with warning messages
-		//One message per property
-		readonly HashSet<object> _warningsPool = new HashSet<object>();
+            // None of the value is equals to the property value.
+            return false;
+        }
+
+        private SerializedProperty FindRelativeProperty(SerializedProperty property, string toGet) {
+            if (property.depth == 0) return property.serializedObject.FindProperty(toGet);
+
+            var path = property.propertyPath.Replace(".Array.data[", "[");
+            var elements = path.Split('.');
+
+            var nestedProperty = NestedPropertyOrigin(property, elements);
+
+            // if nested property is null = we hit an array property
+            if (nestedProperty == null) {
+                var cleanPath = path.Substring(0, path.IndexOf('['));
+                var arrayProp = property.serializedObject.FindProperty(cleanPath);
+                if (_warningsPool.Contains(arrayProp.exposedReferenceValue)) return null;
+                var target = arrayProp.serializedObject.targetObject;
+                var who = string.Format("Property <color=brown>{0}</color> in object <color=brown>{1}</color> caused: ", arrayProp.name,
+                    target.name);
+
+                Debug.LogWarning(who + "Array fields is not supported by [ConditionalFieldAttribute]", target);
+                _warningsPool.Add(arrayProp.exposedReferenceValue);
+                return null;
+            }
+
+            return nestedProperty.FindPropertyRelative(toGet);
+        }
+
+        // For [Serialized] types with [Conditional] fields
+        private SerializedProperty NestedPropertyOrigin(SerializedProperty property, string[] elements) {
+            SerializedProperty parent = null;
+
+            for (int i = 0; i < elements.Length - 1; i++) {
+                var element = elements[i];
+                int index = -1;
+                if (element.Contains("[")) {
+                    index = Convert.ToInt32(element.Substring(element.IndexOf("[", StringComparison.Ordinal))
+                        .Replace("[", "").Replace("]", ""));
+                    element = element.Substring(0, element.IndexOf("[", StringComparison.Ordinal));
+                }
+
+                parent = i == 0
+                    ? property.serializedObject.FindProperty(element)
+                    : parent.FindPropertyRelative(element);
+
+                if (index >= 0) parent = parent.GetArrayElementAtIndex(index);
+            }
+
+            return parent;
+        }
+
+
+        private string AsStringValue(SerializedProperty prop) {
+            switch (prop.propertyType) {
+                case SerializedPropertyType.String:
+                    return prop.stringValue;
+
+                case SerializedPropertyType.Character:
+                case SerializedPropertyType.Integer:
+                    if (prop.type == "char") return Convert.ToChar(prop.intValue).ToString();
+                    return prop.intValue.ToString();
+
+                case SerializedPropertyType.ObjectReference:
+                    return prop.objectReferenceValue != null ? prop.objectReferenceValue.ToString() : "null";
+
+                case SerializedPropertyType.Boolean:
+                    return prop.boolValue.ToString();
+
+                case SerializedPropertyType.Enum:
+                    return prop.enumNames[prop.enumValueIndex];
+
+                default:
+                    return string.Empty;
+            }
+        }
+
+        //This pool is used to prevent spamming with warning messages
+        //One message per property
+        readonly HashSet<object> _warningsPool = new HashSet<object>();
 #endif
-	}
+    }
 }
 #if UNITY_EDITOR
-namespace MyBox.Internal
-{
-	[CustomPropertyDrawer(typeof(ConditionalFieldAttribute))]
-	public class ConditionalFieldAttributeDrawer : PropertyDrawer
-	{
-		private ConditionalFieldAttribute Attribute
-		{
-			get { return _attribute ?? (_attribute = attribute as ConditionalFieldAttribute); }
-		}
+namespace MyBox.Internal {
+    [CustomPropertyDrawer(typeof(ConditionalFieldAttribute))]
+    public class ConditionalFieldAttributeDrawer : PropertyDrawer {
+        private ConditionalFieldAttribute Attribute {
+            get { return _attribute ?? (_attribute = attribute as ConditionalFieldAttribute); }
+        }
 
-		private ConditionalFieldAttribute _attribute;
+        private ConditionalFieldAttribute _attribute;
 
-		private bool _toShow = true;
+        private bool _toShow = true;
 
-		public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
-		{
-			_toShow = Attribute.CheckPropertyVisible(property);
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label) {
+            _toShow = Attribute.CheckPropertyVisible(property);
 
-			return _toShow ? EditorGUI.GetPropertyHeight(property) : 0;
-		}
+            return _toShow ? EditorGUI.GetPropertyHeight(property) : 0;
+        }
 
-		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
-		{
-			if (_toShow) EditorGUI.PropertyField(position, property, label, true);
-		}
-	}
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
+            if (_toShow) EditorGUI.PropertyField(position, property, label, true);
+        }
+    }
 }
 
 #endif


### PR DESCRIPTION
ConditionalField can now compare against multiple values.

```
    public int mainValue;

    [ConditionalField("mainValue", false, 1, 2, 3)]
    public int showWhenIts123; //Only visible when 'mainValue' is either '1', '2' or '3'

    [ConditionalField("mainValue", true, 1, 2, 3)]
    public int showWhenItsNot123; // Only visible when 'mainValue' is neither '1', '2' nor '3'
```

### Small downside
Though one downside of this is the fact that it had affected the parameters in the constructor of ConditionalFieldAttribute, since I had used `params` keyword.
> `ConditionalFieldAttribute(string fieldToCheck, bool inverse = false, params object[] compareValues)...` is the new constructor parameters

This results in the second parameters (`bool inverse = false`) needing to have a value given whenever we want to make a ConditionalField.

### Possible fix to the downside

A fix to the above would be to remove the use of `params` keyword, resulting in this:
```
        public ConditionalFieldAttribute(string fieldToCheck, object[] compareValues = null, bool inverse = false) {
            _fieldToCheck = fieldToCheck;
            _compareValues = compareValues;
            _inverse = inverse;
        }

        // To make someone's life easier if they only want to compare against one object.
        public ConditionalFieldAttribute(string fieldToCheck, object compareValue = null, bool inverse = false) {
            _fieldToCheck = fieldToCheck;

            if (compareValue == null) {
                _compareValues = null;
            } else {
                _compareValues = new object[] { compareValue };
            }
            _inverse = inverse;
        }
```

Though the downside to this is the user needing to manually create a new array of object when they want to compare against multiple values.