### PR TITLE
Added MonoSingleton Type

### DIFF
--- a/Types/MonoSingleton.cs
+++ b/Types/MonoSingleton.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+namespace MyBox{
+
+  public abstract class MonoSingleton<T> : MonoBehaviour where T : MonoBehaviour {
+
+    [SerializeField, Tooltip("True to not destroy this object when it loads")]
+    private bool dontDestroyOnLoad;
+
+    private static T _instance;
+
+    public static T Instance {
+      get {
+        if (_instance == null) {
+          _instance = FindObjectOfType<T>();
+          if (_instance == null) {
+            Debug.LogError("Singleton Instance caused: " + typeof(T).Name + " not found on scene");
+          }
+        }
+
+        return _instance;
+      }
+    }
+
+    private void Awake() {
+      var instance = Instance;
+
+      if (dontDestroyOnLoad) {
+        // Ensure that the instance actually exists before we do a "DontDestroyOnLoad" on it.
+        if (instance != null) {
+          DontDestroyOnLoad(instance);
+        }
+      }
+
+      OnAwake();
+    }
+
+    protected abstract void OnAwake();
+
+  }
+}

--- a/Types/MonoSingleton.cs
+++ b/Types/MonoSingleton.cs
@@ -1,41 +1,47 @@
 using UnityEngine;
 
-namespace MyBox{
+namespace MyBox
+{
+    public abstract class MonoSingleton<T> : MonoBehaviour where T : MonoBehaviour
+    {
+        [SerializeField, Tooltip("True to not destroy this object when it loads")]
+        private bool dontDestroyOnLoad;
 
-  public abstract class MonoSingleton<T> : MonoBehaviour where T : MonoBehaviour {
+        private static T _instance;
 
-    [SerializeField, Tooltip("True to not destroy this object when it loads")]
-    private bool dontDestroyOnLoad;
+        public static T Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = FindObjectOfType<T>();
+                    if (_instance == null)
+                    {
+                        Debug.LogError("Singleton Instance caused: " + typeof(T).Name + " not found on scene");
+                    }
+                }
 
-    private static T _instance;
-
-    public static T Instance {
-      get {
-        if (_instance == null) {
-          _instance = FindObjectOfType<T>();
-          if (_instance == null) {
-            Debug.LogError("Singleton Instance caused: " + typeof(T).Name + " not found on scene");
-          }
+                return _instance;
+            }
         }
 
-        return _instance;
-      }
-    }
+        private void Awake()
+        {
+            var instance = Instance;
 
-    private void Awake() {
-      var instance = Instance;
+            if (dontDestroyOnLoad)
+            {
+                // Ensure that the instance actually exists before we do a "DontDestroyOnLoad" on it.
+                if (instance != null)
+                {
+                    DontDestroyOnLoad(instance);
+                }
+            }
 
-      if (dontDestroyOnLoad) {
-        // Ensure that the instance actually exists before we do a "DontDestroyOnLoad" on it.
-        if (instance != null) {
-          DontDestroyOnLoad(instance);
+            OnAwake();
         }
-      }
 
-      OnAwake();
+        protected abstract void OnAwake();
     }
-
-    protected abstract void OnAwake();
-
-  }
 }

--- a/Types/MonoSingleton.cs.meta
+++ b/Types/MonoSingleton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fe030faac94466140b78f5375abc62a8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Same functionality as `Singleton`, but you can choose to apply a DontDestroyOnLoad on it via the inspector.

However, it inherits from MonoBehaviour unlike the original `Singleton`. This is due to it using `Awake` call to apply a `DontDestroyOnLoad` on the instance if need.<br>The child class will need to override an `OnAwake` function. (simulates an `Awake` call)

I decided to keep the original `Singleton`, and made this into `MonoSingleton` due to the above stated differences.

P.S: *Also, should we make the original `Singleton` class an abstract?*