### PR TITLE
Added MySceneBundle

### DIFF
--- a/Extensions/MySceneBundle.cs
+++ b/Extensions/MySceneBundle.cs
@@ -1,0 +1,288 @@
+﻿using System.Collections.Generic;
+
+using UnityEngine.SceneManagement;
+
+using MyBox.Internal;
+
+namespace MyBox
+{
+
+    /// <summary>
+    /// For passing objects between different scenes in Unity.
+    /// </summary>
+    public static class MySceneBundle
+    {
+
+        private static SceneBundle currentSceneBundle;
+        private static SceneBundle nextSceneBundle;
+
+        static MySceneBundle()
+        {
+            currentSceneBundle = new SceneBundle();
+            nextSceneBundle = new SceneBundle();
+
+#if UNITY_EDITOR
+            UnityEditor.SceneManagement.EditorSceneManager.activeSceneChanged += PrepareSceneBundleForNextScene;
+#else
+            SceneManager.activeSceneChanged += PrepareSceneBundleForNextScene;
+
+#endif
+        }
+
+        private static void PrepareSceneBundleForNextScene(Scene currentScene, Scene newScene)
+        {
+            currentSceneBundle = nextSceneBundle;
+            nextSceneBundle = new SceneBundle();
+        }
+
+        /// <summary>
+        /// Carry over all data in the current bundle to the next bundle.
+        /// </summary>
+        /// <param name="overrideData">True to override any data in the next bundle.</param>
+        public static void CarryOverCurrentBundleToNextBundle(bool overrideData = false)
+        {
+            nextSceneBundle.BoolData.AddBundleData(currentSceneBundle.BoolData, overrideData);
+            nextSceneBundle.IntData.AddBundleData(currentSceneBundle.IntData, overrideData);
+            nextSceneBundle.FloatData.AddBundleData(currentSceneBundle.FloatData, overrideData);
+            nextSceneBundle.StringData.AddBundleData(currentSceneBundle.StringData, overrideData);
+            nextSceneBundle.ObjectData.AddBundleData(currentSceneBundle.ObjectData, overrideData);
+        }
+
+        #region Add_Data_Functions
+
+        /// <summary>
+        /// Add a string value data that will be carried over to the next scene.
+        /// </summary>
+        /// <param name="dataKey">The key to identify the data you are storing.</param>
+        /// <param name="data"></param>
+        /// <param name="overrideIfExists">True to override if a data with the same key already exists</param>
+        public static void AddStringDataToBundle(string dataKey, string data, bool overrideIfExists = true)
+        {
+            nextSceneBundle.StringData.AddData(dataKey, data, overrideIfExists);
+        }
+
+        /// <summary>
+        /// Add a float value data that will be carried over to the next scene.
+        /// </summary>
+        /// <param name="dataKey">The key to identify the data you are storing.</param>
+        /// <param name="data"></param>
+        /// <param name="overrideIfExists">True to override if a data with the same key already exists</param>
+        public static void AddFloatDataToBundle(string dataKey, float data, bool overrideIfExists = true)
+        {
+            nextSceneBundle.FloatData.AddData(dataKey, data, overrideIfExists);
+        }
+
+        /// <summary>
+        /// Add a integer value data that will be carried over to the next scene.
+        /// </summary>
+        /// <param name="dataKey">The key to identify the data you are storing.</param>
+        /// <param name="data"></param>
+        /// <param name="overrideIfExists">True to override if a data with the same key already exists</param>
+        public static void AddIntDataToBundle(string dataKey, int data, bool overrideIfExists = true)
+        {
+            nextSceneBundle.IntData.AddData(dataKey, data, overrideIfExists);
+        }
+
+        /// <summary>
+        /// Add a bool value data that will be carried over to the next scene.
+        /// </summary>
+        /// <param name="dataKey">The key to identify the data you are storing.</param>
+        /// <param name="data"></param>
+        /// <param name="overrideIfExists">True to override if a data with the same key already exists</param>
+        public static void AddBoolDataToBundle(string dataKey, bool data, bool overrideIfExists = true)
+        {
+            nextSceneBundle.BoolData.AddData(dataKey, data, overrideIfExists);
+        }
+
+        /// <summary>
+        /// Add a object value data that will be carried over to the next scene.
+        /// </summary>
+        /// <param name="dataKey">The key to identify the data you are storing.</param>
+        /// <param name="data"></param>
+        /// <param name="overrideIfExists">True to override if a data with the same key already exists</param>
+        public static void AddObjectDataToBundle(string dataKey, object data, bool overrideIfExists = true)
+        {
+            nextSceneBundle.ObjectData.AddData(dataKey, data, overrideIfExists);
+        }
+
+
+        #endregion
+
+        #region Get_Data_Functions
+
+        /// <summary>
+        /// Try to fetch a string data from the bundle that was passed from the previous scene.
+        /// </summary>
+        /// <param name="dataKey">The identifier for the data to fetch</param>
+        /// <param name="result">Result of the data (Default or null if it does not exists)</param>
+        /// <returns>True if the data with the key exists.</returns>
+        public static bool TryGetStringDataFromBundle(string dataKey, out string result)
+        {
+            return currentSceneBundle.StringData.TryGetData(dataKey, out result);
+        }
+
+        /// <summary>
+        /// Try to fetch a float data from the bundle that was passed from the previous scene.
+        /// </summary>
+        /// <param name="dataKey">The identifier for the data to fetch</param>
+        /// <param name="result">Result of the data (Default or null if it does not exists)</param>
+        /// <returns>True if the data with the key exists.</returns>
+        public static bool TryGetFloatDataFromBundle(string dataKey, out float result)
+        {
+            return currentSceneBundle.FloatData.TryGetData(dataKey, out result);
+        }
+
+        /// <summary>
+        /// Try to fetch an integer data from the bundle that was passed from the previous scene.
+        /// </summary>
+        /// <param name="dataKey">The identifier for the data to fetch</param>
+        /// <param name="result">Result of the data (Default or null if it does not exists)</param>
+        /// <returns>True if the data with the key exists.</returns>
+        public static bool TryGetIntDataFromBundle(string dataKey, out int result)
+        {
+            return currentSceneBundle.IntData.TryGetData(dataKey, out result);
+        }
+
+        /// <summary>
+        /// Try to fetch a bool data from the bundle that was passed from the previous scene.
+        /// </summary>
+        /// <param name="dataKey">The identifier for the data to fetch</param>
+        /// <param name="result">Result of the data (Default or null if it does not exists)</param>
+        /// <returns>True if the data with the key exists.</returns>
+        public static bool TryGetBoolDataFromBundle(string dataKey, out bool result)
+        {
+            return currentSceneBundle.BoolData.TryGetData(dataKey, out result);
+        }
+
+        /// <summary>
+        /// Try to fetch an object data from the bundle that was passed from the previous scene.
+        /// </summary>
+        /// <param name="dataKey">The identifier for the data to fetch</param>
+        /// <param name="result">Result of the data (Default or null if it does not exists)</param>
+        /// <returns>True if the data with the key exists.</returns>
+        public static bool TryGetObjectDataFromBundle(string dataKey, out object result)
+        {
+            return currentSceneBundle.ObjectData.TryGetData(dataKey, out result);
+        }
+
+        #endregion
+
+    }
+}
+
+namespace MyBox.Internal
+{
+
+    internal class SceneBundle
+    {
+
+        private Bundle<string> stringData;
+        private Bundle<float> floatData;
+        private Bundle<int> intData;
+        private Bundle<bool> boolData;
+
+        private Bundle<object> objectData;
+
+        internal SceneBundle()
+        {
+            stringData = new Bundle<string>();
+            floatData = new Bundle<float>();
+            intData = new Bundle<int>();
+            boolData = new Bundle<bool>();
+            objectData = new Bundle<object>();
+        }
+
+        internal Bundle<string> StringData { get => stringData; }
+        internal Bundle<float> FloatData { get => floatData; }
+        internal Bundle<int> IntData { get => intData; }
+        internal Bundle<bool> BoolData { get => boolData; }
+        internal Bundle<object> ObjectData { get => objectData; }
+    }
+
+    internal class Bundle<T>
+    {
+        private Dictionary<string, T> bundleData;
+
+        internal Bundle()
+        {
+            bundleData = new Dictionary<string, T>();
+        }
+
+        /// <summary>
+        /// Adds a data to this bundle
+        /// </summary>
+        /// <param name="dataKey">The key to identify this data</param>
+        /// <param name="data"></param>
+        /// <param name="overrideIfExists">True to override this data if it exists</param>
+        internal void AddData(string dataKey, T data, bool overrideIfExists = true)
+        {
+            bool haveDataWithSameKey = bundleData.ContainsKey(dataKey);
+
+            if (haveDataWithSameKey && overrideIfExists)
+            {
+                bundleData[dataKey] = data;
+            }
+            else if (!haveDataWithSameKey)
+            {
+                bundleData.Add(dataKey, data);
+            }
+        }
+
+        internal void AddData(KeyValuePair<string, T> keyValuePair, bool overrideIfExists = true)
+        {
+            bool haveDataWithSameKey = bundleData.ContainsKey(keyValuePair.Key);
+
+            if (haveDataWithSameKey && overrideIfExists)
+            {
+                bundleData[keyValuePair.Key] = keyValuePair.Value;
+            }
+            else if (!haveDataWithSameKey)
+            {
+                bundleData.Add(keyValuePair.Key, keyValuePair.Value);
+            }
+        }
+
+        internal bool TryGetData(string dataKey, out T result)
+        {
+            return bundleData.TryGetValue(dataKey, out result);
+        }
+
+        /// <summary>
+        /// True if a data with the datakey exists
+        /// </summary>
+        /// <param name="dataKey"></param>
+        /// <returns></returns>
+        internal bool DataExists(string dataKey)
+        {
+            return bundleData.ContainsKey(dataKey);
+        }
+
+        internal Dictionary<string, T> GetBundleData()
+        {
+            return new Dictionary<string, T>(new Dictionary<string, T>(bundleData));
+        }
+
+        /// <summary>
+        /// Add a bundle of data to this bundle
+        /// </summary>
+        /// <param name="bundle">The data bundle</param>
+        /// <param name="overrideIfExists">True to override if any of the data already exists in this data bundle</param>
+        internal void AddBundleData(Dictionary<string, T> bundle, bool overrideIfExists)
+        {
+            foreach (var data in bundle)
+            {
+                AddData(data, overrideIfExists);
+            }
+        }
+
+        /// <summary>
+        /// Add a bundle of data to this bundle
+        /// </summary>
+        /// <param name="bundle">The data bundle</param>
+        /// <param name="overrideIfExists">True to override the data if it already exists in this data bundle</param>
+        internal void AddBundleData(Bundle<T> bundle, bool overrideIfExists)
+        {
+            AddBundleData(bundle.bundleData, overrideIfExists);
+        }
+    }
+}

--- a/Extensions/MySceneBundle.cs.meta
+++ b/Extensions/MySceneBundle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 951d2e3a3ee4a4b459b7fc3a461e66f9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Implemented it in one of my projects that I was doing; It allows transferring of objects from one scene to another.<br>(Not game-objects, just objects in general)

#### Example:

```
MyBox.MySceneBundle.AddFloatDataToBundle("myKey", 10f)
```
 would add a data to the next scene.

On the next scene,
```
bool hasValue = MyBox.MySceneBundle.TryGetFloatDataFromBundle("myKey", out float storedData)
```
would retrieve the data.<Br>The returned boolean would be true if data did exists.<br>If the data did not exists, the boolean would be false and the float will be a default value (0f). 

#### Issue (Non-blocking)
The data does not transfer *before* the unity `Awake()` calls, which means fetching data during `Awake` function would not work. (Though it works on `Start`)

Currently I am using the [`SceneManager.activeSceneChanged`](https://docs.unity3d.com/ScriptReference/SceneManagement.SceneManager-activeSceneChanged.html) event to invoke transferring of data, and that was the best I could find in the unity API.<br>
Please feel free to change it if you find another better event-listener or method to use.

*(P.S I placed it in the `extensions` folder since I did not know which folder to actually place this in.)*


