### PR TITLE
Add some extension methods.

### DIFF
--- a/Extensions/MyCollections.cs
+++ b/Extensions/MyCollections.cs
@@ -232,5 +232,11 @@ namespace MyBox
 			
 			return source.Values.ContentsMatch(check);
 		}
+
+		/// <summary>
+		/// Gets the value associated with the specified key if it exists, or return the default value for the value type if it doesn't.
+		/// </summary>
+		public static TValue GetOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> source, TKey key) =>
+			source.IsNullOrEmpty() ? default(TValue) : source.ContainsKey(key) ? source[key] : default(TValue);
 	}
 }

--- a/Extensions/MyCollections.cs
+++ b/Extensions/MyCollections.cs
@@ -238,5 +238,33 @@ namespace MyBox
 		/// </summary>
 		public static TValue GetOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> source, TKey key) =>
 			source.IsNullOrEmpty() ? default(TValue) : source.ContainsKey(key) ? source[key] : default(TValue);
+
+		/// <summary>
+		/// Performs an action on each element of a collection.
+		/// </summary>
+		public static IEnumerable<T> ForEach<T>(this IEnumerable<T> source, System.Action<T> action)
+		{
+			if (source.IsNullOrEmpty())
+			{
+				Debug.LogError("ForEach Caused: source collection is null or empty");
+				return null;
+			}
+			foreach (T element in source) action(element);
+			return source;
+		}
+
+		/// <summary>
+		/// Performs a function on each element of a collection.
+		/// </summary>
+		public static IEnumerable<T> ForEach<T, R>(this IEnumerable<T> source, System.Func<T, R> func)
+		{
+			if (source.IsNullOrEmpty())
+			{
+				Debug.LogError("ForEach Caused: source collection is null or empty");
+				return null;
+			}
+			foreach (T element in source) func(element);
+			return source;
+		}
 	}
 }


### PR DESCRIPTION
`GetOrDefault`: a convenience extension method to always have something returned from an `IDictionary` without running into `KeyNotFoundException`. If `TValue` is a reference type, the return value can continue execution chain safely using the `?.` null-conditional operation.

`ForEach`: does the same thing as [`List<T>.ForEach` ](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.list-1.foreach?view=netcore-3.1)but for every type of collection, LINQ friendly. Also included a version that accepts `System.Func` because lord knows, there are a lot of impure functions in Unity.