### PR TITLE
Add some extension methods round 3

### DIFF
--- a/Extensions/MyAlgorithms.cs
+++ b/Extensions/MyAlgorithms.cs
@@ -8,10 +8,10 @@ namespace MyBox
 		/// Take an object and pass it as an argument to a void function.
 		/// </summary>
 		public static T Pipe<T>(this T argument, Action<T> action)
-    {
-      action(argument);
-      return argument;
-    }
+		{
+			action(argument);
+			return argument;
+		}
 
 		/// <summary>
 		/// Take an object, pass it as an argument to a function, return the result.

--- a/Extensions/MyAlgorithms.cs
+++ b/Extensions/MyAlgorithms.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace MyBox
+{
+	public static class MyAlgorithms
+	{
+		/// <summary>
+		/// Take an object and pass it as an argument to a void function.
+		/// </summary>
+		public static T Pipe<T>(this T argument, Action<T> action)
+    {
+      action(argument);
+      return argument;
+    }
+
+		/// <summary>
+		/// Take an object, pass it as an argument to a function, return the result.
+		/// </summary>
+		public static R Pipe<T, R>(this T argument, Func<T, R> function) =>
+			function(argument);
+
+		/// <summary>
+		/// Take an object, pass it as an argument to a function, return the object.
+		/// </summary>
+		public static T PipeKeep<T, R>(this T argument, Func<T, R> function)
+		{
+			function(argument);
+			return argument;
+		}
+	}
+}

--- a/Extensions/MyAlgorithms.cs.meta
+++ b/Extensions/MyAlgorithms.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f124183e25b4eb04681a42b28f6b3cb7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Extensions/MyString.cs
+++ b/Extensions/MyString.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.RegularExpressions;
+using System;
 
 namespace MyBox
 {
@@ -71,6 +72,12 @@ namespace MyBox
 		{
 			return string.Format("<i>{0}</i>", message);
 		}
+
+		/// <summary>
+		/// Convert a string value to an Enum value.
+		/// </summary>
+		public static T AsEnum<T>(this string source) =>
+			(T)Enum.Parse(typeof(T), source);
 	}
 
 	public enum Colors


### PR DESCRIPTION
Just syntactic sugar this round.

`Pipe`: A common pattern we encounter is taking the result of one function and use it as the argument for the next. The `Pipe` and `PipeKeep` extension methods help turning Lisp-y, reversed-order nested calls like `Func4(Func3(Func2(Func1(originalArgument))))` into `Func1(originalArgument).Pipe(Func2).Pipe(Func3).Pipe(Func4)`. 

`AsEnum<T>`: Converting a number to an enum is a straightfoward cast. Converting string representing an enum's value name is a call to `Enum.Parse` with an additional cast, repeating the type name twice in the process. Given an enum like `enum Rarity { Normal, Uncommon, Rare }`, AsEnum<T> would turn a conversion from `(Rarity)Enum.Parse(typeof(Rarity), "Rare") `into `"Rare".AsEnum<Rarity>()`.