### PR TITLE
Add some extension methods round 4

### DIFF
--- a/Extensions/MyCollections.cs
+++ b/Extensions/MyCollections.cs
@@ -214,7 +214,7 @@ namespace MyBox
 		/// <summary>
 		/// Is Keys in MyDictionary is the same as some collection
 		/// </summary>
-		public static bool ContentsMatchKeys<T1, T2>(this MyDictionary<T1, T2> source, IEnumerable<T1> check)
+		public static bool ContentsMatchKeys<T1, T2>(this IDictionary<T1, T2> source, IEnumerable<T1> check)
 		{
 			if (source.IsNullOrEmpty() && check.IsNullOrEmpty()) return true;
 			if (source.IsNullOrEmpty() || check.IsNullOrEmpty()) return false;
@@ -225,7 +225,7 @@ namespace MyBox
 		/// <summary>
 		/// Is Values in MyDictionary is the same as some collection
 		/// </summary>
-		public static bool ContentsMatchValues<T1, T2>(this MyDictionary<T1, T2> source, IEnumerable<T2> check)
+		public static bool ContentsMatchValues<T1, T2>(this IDictionary<T1, T2> source, IEnumerable<T2> check)
 		{
 			if (source.IsNullOrEmpty() && check.IsNullOrEmpty()) return true;
 			if (source.IsNullOrEmpty() || check.IsNullOrEmpty()) return false;

--- a/Extensions/MyMath.cs
+++ b/Extensions/MyMath.cs
@@ -26,13 +26,7 @@ namespace MyBox
 		/// <summary>
 		/// Returns the sign 1/-1 evaluated at the given value.
 		/// </summary>
-		public static int Sign(float x)
-		{
-			if (x > 0) return 1;
-			if (x < 0) return -1;
-
-			return 0;
-		}
+		public static int Sign(IComparable x) => x.CompareTo(0);
 		
 		/// <summary>
 		/// Shortcut for Mathf.Approximately

--- a/Extensions/MyString.cs
+++ b/Extensions/MyString.cs
@@ -76,8 +76,8 @@ namespace MyBox
 		/// <summary>
 		/// Convert a string value to an Enum value.
 		/// </summary>
-		public static T AsEnum<T>(this string source) =>
-			(T)Enum.Parse(typeof(T), source);
+		public static T AsEnum<T>(this string source, bool ignoreCase = true) =>
+			(T)Enum.Parse(typeof(T), source, ignoreCase);
 	}
 
 	public enum Colors

--- a/Extensions/MyString.cs
+++ b/Extensions/MyString.cs
@@ -76,7 +76,8 @@ namespace MyBox
 		/// <summary>
 		/// Convert a string value to an Enum value.
 		/// </summary>
-		public static T AsEnum<T>(this string source, bool ignoreCase = true) =>
+		public static T AsEnum<T>(this string source, bool ignoreCase = true)
+			where T : System.Enum =>
 			(T)Enum.Parse(typeof(T), source, ignoreCase);
 	}
 

--- a/Extensions/MyVectors.cs
+++ b/Extensions/MyVectors.cs
@@ -442,12 +442,12 @@ namespace MyBox
 			return position.GetClosest(positions);
 		}
 
-        #endregion
+		#endregion
 
-        public static Vector4 To(this Vector4 source, Vector4 destination) =>
-            destination - source;
+		public static Vector4 To(this Vector4 source, Vector4 destination) =>
+			destination - source;
 
-        public static Vector3 To(this Vector3 source, Vector3 destination) =>
+		public static Vector3 To(this Vector3 source, Vector3 destination) =>
 			destination - source;
 
 		public static Vector2 To(this Vector2 source, Vector2 destination) =>

--- a/Extensions/MyVectors.cs
+++ b/Extensions/MyVectors.cs
@@ -443,5 +443,23 @@ namespace MyBox
 		}
 
 		#endregion
+
+		public static Vector3 To(this Vector3 source, Vector3 destination) =>
+			source - destination;
+
+		public static Vector2 To(this Vector2 source, Vector2 destination) =>
+			source - destination;
+
+		public static Vector3 To(this Component source, Component target) =>
+			source.transform.position.To(target.transform.position);
+
+		public static Vector3 To(this Component source, GameObject target) =>
+			source.transform.position.To(target.transform.position);
+
+		public static Vector3 To(this GameObject source, Component target) =>
+			source.transform.position.To(target.transform.position);
+
+		public static Vector3 To(this GameObject source, GameObject target) =>
+			source.transform.position.To(target.transform.position);
 	}
 }

--- a/Extensions/MyVectors.cs
+++ b/Extensions/MyVectors.cs
@@ -442,9 +442,12 @@ namespace MyBox
 			return position.GetClosest(positions);
 		}
 
-		#endregion
+        #endregion
 
-		public static Vector3 To(this Vector3 source, Vector3 destination) =>
+        public static Vector4 To(this Vector4 source, Vector4 destination) =>
+            destination - source;
+
+        public static Vector3 To(this Vector3 source, Vector3 destination) =>
 			destination - source;
 
 		public static Vector2 To(this Vector2 source, Vector2 destination) =>

--- a/Extensions/MyVectors.cs
+++ b/Extensions/MyVectors.cs
@@ -445,10 +445,10 @@ namespace MyBox
 		#endregion
 
 		public static Vector3 To(this Vector3 source, Vector3 destination) =>
-			source - destination;
+			destination - source;
 
 		public static Vector2 To(this Vector2 source, Vector2 destination) =>
-			source - destination;
+			destination - source;
 
 		public static Vector3 To(this Component source, Component target) =>
 			source.transform.position.To(target.transform.position);


### PR DESCRIPTION
`To`: I always find it unintuitive to get a vector from `origin -> destination` by writing `destination - origin`. `To` is a set of extension methods that allow you to write `origin.To(destination)` in an intuitive way. I also provided `To` as a shorthand for 2 Unity built-in types that have a transform property: `Component` and `GameObject`. Note that `Transform` is a sub-type of `Component`.

`ContentsMatchKeys`/`ContentsMatchValues`: These 2 extension methods originally only took in a custom `MyDictionary` type. I see no reason they can't take a general-purpose `IDictionary` interface instead.

`MyMath.Sign`: This extension method previously took in only the `float` type. Since its behaviour is the same as the result of a `IComparable.CompareTo` call, I changed its parameter type to `IComparable` to take in more types than just `float`.

`AsEnum`: The first implementation of this extension method uses `Enum.Parse`. Since that method takes in an optional `ignoreCase` argument, I revised `AsEnum` to take in an optional `ignoreCase` argument as well. Also new for this method is a type constraint. `AsEnum` now only takes in sub-type of `System.Enum` which makes it more type-safe than the built-in `Enum.Parse` method.