### PR TITLE
Add some extension methods round 5

### DIFF
--- a/Extensions/MyAlgorithms.cs
+++ b/Extensions/MyAlgorithms.cs
@@ -13,15 +13,14 @@ namespace MyBox
 		/// <summary>
 		/// Check if this is a particular type.
 		/// </summary>
-		public static bool Is<R>(this System.Object source) => source is R;
+		public static bool Is<R>(this object source) => source is R;
 
 		/// <summary>
 		/// Cast to a different type, exception-safe.
 		/// </summary>
-		public static R As<R>(this System.Object source) where R : class
+		public static R As<R>(this object source) where R : class
 		{
-			if (source is R) return source as R;
-			return null;
+			return source as R;
 		}
 
 		/// <summary>

--- a/Extensions/MyAlgorithms.cs
+++ b/Extensions/MyAlgorithms.cs
@@ -5,6 +5,26 @@ namespace MyBox
 	public static class MyAlgorithms
 	{
 		/// <summary>
+		/// Convert to a different type.
+		/// </summary>
+		public static R Cast<R>(this IConvertible source) =>
+			(R)Convert.ChangeType(source, typeof(R));
+
+		/// <summary>
+		/// Check if this is a particular type.
+		/// </summary>
+		public static bool Is<R>(this System.Object source) => source is R;
+
+		/// <summary>
+		/// Cast to a different type, exception-safe.
+		/// </summary>
+		public static R As<R>(this System.Object source) where R : class
+		{
+			if (source is R) return source as R;
+			return null;
+		}
+
+		/// <summary>
 		/// Take an object and pass it as an argument to a void function.
 		/// </summary>
 		public static T Pipe<T>(this T argument, Action<T> action)

--- a/Extensions/MyCollections.cs
+++ b/Extensions/MyCollections.cs
@@ -302,6 +302,6 @@ namespace MyBox
 		public static T MinBy<T, S>(this IEnumerable<T> source, Func<T, S> selector)
 			where S : IComparable<S>
 			=> source.Aggregate(default(T),
-				(e, n) => selector(e).CompareTo(selector(n)) > 0 ? e : n);
+				(e, n) => selector(e).CompareTo(selector(n)) < 0 ? e : n);
 	}
 }

--- a/Extensions/MyCollections.cs
+++ b/Extensions/MyCollections.cs
@@ -293,15 +293,27 @@ namespace MyBox
 		/// </summary>
 		public static T MaxBy<T, S>(this IEnumerable<T> source, Func<T, S> selector)
 			where S : IComparable<S>
-			=> source.Aggregate(default(T),
-				(e, n) => selector(e).CompareTo(selector(n)) > 0 ? e : n);
+		{
+			if (source.IsNullOrEmpty())
+			{
+				Debug.LogError("MaxBy Caused: source collection is null or empty");
+				return default(T);
+			}
+			return source.Aggregate((e, n) => selector(e).CompareTo(selector(n)) > 0 ? e : n);
+		}
 
 		/// <summary>
 		/// Find the element of a collection that has the lowest selected value.
 		/// </summary>
 		public static T MinBy<T, S>(this IEnumerable<T> source, Func<T, S> selector)
 			where S : IComparable<S>
-			=> source.Aggregate(default(T),
-				(e, n) => selector(e).CompareTo(selector(n)) < 0 ? e : n);
+		{
+			if (source.IsNullOrEmpty())
+			{
+				Debug.LogError("MinBy Caused: source collection is null or empty");
+				return default(T);
+			}
+			return source.Aggregate((e, n) => selector(e).CompareTo(selector(n)) < 0 ? e : n);
+		}
 	}
 }

--- a/Extensions/MyCollections.cs
+++ b/Extensions/MyCollections.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
 using System.Linq;
+using System;
 
 namespace MyBox
 {
@@ -72,7 +73,7 @@ namespace MyBox
 		/// </summary>
 		public static T GetRandom<T>(this T[] collection)
 		{
-			return collection[Random.Range(0, collection.Length)];
+			return collection[UnityEngine.Random.Range(0, collection.Length)];
 		}
 		
 		/// <summary>
@@ -80,7 +81,7 @@ namespace MyBox
 		/// </summary>
 		public static T GetRandom<T>(this IList<T> collection)
 		{
-			return collection[Random.Range(0, collection.Count)];
+			return collection[UnityEngine.Random.Range(0, collection.Count)];
 		}
 		
 		/// <summary>
@@ -88,7 +89,7 @@ namespace MyBox
 		/// </summary>
 		public static T GetRandom<T>(this IEnumerable<T> collection)
 		{
-			return collection.ElementAt(Random.Range(0, collection.Count()));
+			return collection.ElementAt(UnityEngine.Random.Range(0, collection.Count()));
 		}
 		
 		
@@ -106,7 +107,7 @@ namespace MyBox
 			
 			for (var i = 0; i < amount; i++)
 			{
-				var random = Random.Range(0, indexes.Count);
+				var random = UnityEngine.Random.Range(0, indexes.Count);
 				randoms[i] = collection[random];
 				indexes.RemoveAt(random);
 			}
@@ -234,10 +235,30 @@ namespace MyBox
 		}
 
 		/// <summary>
-		/// Gets the value associated with the specified key if it exists, or return the default value for the value type if it doesn't.
+		/// Gets the value associated with the specified key if it exists, or
+		/// return the default value for the value type if it doesn't.
 		/// </summary>
-		public static TValue GetOrDefault<TKey, TValue>(this IDictionary<TKey, TValue> source, TKey key) =>
-			source.IsNullOrEmpty() ? default(TValue) : source.ContainsKey(key) ? source[key] : default(TValue);
+		public static TValue GetOrDefault<TKey, TValue>(
+			this IDictionary<TKey, TValue> source,
+			TKey key,
+			TValue customDefault = default(TValue))
+		{
+			if (!source.ContainsKey(key)) source[key] = customDefault;
+			return source[key];
+		}
+
+		/// <summary>
+		/// Gets the value associated with the specified key if it exists, or
+		/// generate a value for the new key if it doesn't.
+		/// </summary>
+		public static TValue GetOrDefault<TKey, TValue>(
+			this IDictionary<TKey, TValue> source,
+			TKey key,
+			System.Func<TValue> customDefaultGenerator)
+		{
+			if (!source.ContainsKey(key)) source[key] = customDefaultGenerator();
+			return source[key];
+		}
 
 		/// <summary>
 		/// Performs an action on each element of a collection.
@@ -256,7 +277,7 @@ namespace MyBox
 		/// <summary>
 		/// Performs a function on each element of a collection.
 		/// </summary>
-		public static IEnumerable<T> ForEach<T, R>(this IEnumerable<T> source, System.Func<T, R> func)
+		public static IEnumerable<T> ForEach<T, R>(this IEnumerable<T> source, Func<T, R> func)
 		{
 			if (source.IsNullOrEmpty())
 			{
@@ -266,5 +287,21 @@ namespace MyBox
 			foreach (T element in source) func(element);
 			return source;
 		}
+
+		/// <summary>
+		/// Find the element of a collection that has the highest selected value.
+		/// </summary>
+		public static T MaxBy<T, S>(this IEnumerable<T> source, Func<T, S> selector)
+			where S : IComparable<S>
+			=> source.Aggregate(default(T),
+				(e, n) => selector(e).CompareTo(selector(n)) > 0 ? e : n);
+
+		/// <summary>
+		/// Find the element of a collection that has the lowest selected value.
+		/// </summary>
+		public static T MinBy<T, S>(this IEnumerable<T> source, Func<T, S> selector)
+			where S : IComparable<S>
+			=> source.Aggregate(default(T),
+				(e, n) => selector(e).CompareTo(selector(n)) > 0 ? e : n);
 	}
 }


### PR DESCRIPTION
`Cast`: Syntactic sugar. Mostly created to shift casting operation from RTL to LTR to maintain the flow of our code reading, so that `((int)1f).InRange(someRangedInt)` can now be written as `1f.Cast<int>().InRange(someRangedInt)`. It's actually a conversion procedure that takes in an `IConvertible`, which includes all C# primitive types and all enum types.

`Is`: Syntactic sugar. Same as the` is` operator, but saves us one extra pair of parentheses so we can write `if (!enemy.Is<BossEnemy>())` instead of `if (!(enemy is BossEnemy))`. Makes code looks less Lisp-y.

`As`: Mostly same as `as` operator, with one difference: an incompatible cast using either the `as` operator or the regular cast syntax will thow an `InvalidCastException`. This requires us to write around the possibility of throwing exceptions like this:
```
if (enemy is BossEnemy)
{
  var boss = enemy as BossEnemy;
  // continue interacting with boss
}
```
The `As` extension method will return null instead of throwing an exception so that you can write `enemy.As<BossEnemy>()?.Pipe(b => { /* continue interacting with boss */ });`.

`GetOrDefault`: I expanded this extension method to allow an additional custom default value in the case a dictionary doesn't have a particular key. Also new is an overload that takes in a generator function to create a value for a key if it doesn't exist yet, so you can do things like instantiating a new object for each missing key.

`MaxBy`/`MinBy`: Given a `Students` collection, `Students.Max(s => s.Score)` will return the highest score among those students. Whereas `Students.MaxBy(s => s.Score)` will return the student (that is, the element of the `Students` collection) who has that highest score. Vice versa for `Min`/`MinBy`. `MaxBy`/`MinBy` actually can select any type that implements `IComparable`.