### PR TITLE
Add some extension methods round 6

### DIFF
--- a/Extensions/MyCollections.cs
+++ b/Extensions/MyCollections.cs
@@ -265,7 +265,6 @@ namespace MyBox
 		/// </summary>
 		public static IEnumerable<T> ForEach<T>(this IEnumerable<T> source, System.Action<T> action)
 		{
-			if (source.IsNullOrEmpty()) return source;
 			foreach (T element in source) action(element);
 			return source;
 		}
@@ -275,7 +274,6 @@ namespace MyBox
 		/// </summary>
 		public static IEnumerable<T> ForEach<T, R>(this IEnumerable<T> source, Func<T, R> func)
 		{
-			if (source.IsNullOrEmpty()) return source;
 			foreach (T element in source) func(element);
 			return source;
 		}

--- a/Extensions/MyCollections.cs
+++ b/Extensions/MyCollections.cs
@@ -265,11 +265,7 @@ namespace MyBox
 		/// </summary>
 		public static IEnumerable<T> ForEach<T>(this IEnumerable<T> source, System.Action<T> action)
 		{
-			if (source.IsNullOrEmpty())
-			{
-				Debug.LogError("ForEach Caused: source collection is null or empty");
-				return source;
-			}
+			if (source.IsNullOrEmpty()) return source;
 			foreach (T element in source) action(element);
 			return source;
 		}
@@ -279,11 +275,7 @@ namespace MyBox
 		/// </summary>
 		public static IEnumerable<T> ForEach<T, R>(this IEnumerable<T> source, Func<T, R> func)
 		{
-			if (source.IsNullOrEmpty())
-			{
-				Debug.LogError("ForEach Caused: source collection is null or empty");
-				return source;
-			}
+			if (source.IsNullOrEmpty()) return source;
 			foreach (T element in source) func(element);
 			return source;
 		}

--- a/Extensions/MyCollections.cs
+++ b/Extensions/MyCollections.cs
@@ -268,7 +268,7 @@ namespace MyBox
 			if (source.IsNullOrEmpty())
 			{
 				Debug.LogError("ForEach Caused: source collection is null or empty");
-				return null;
+				return source;
 			}
 			foreach (T element in source) action(element);
 			return source;
@@ -282,7 +282,7 @@ namespace MyBox
 			if (source.IsNullOrEmpty())
 			{
 				Debug.LogError("ForEach Caused: source collection is null or empty");
-				return null;
+				return source;
 			}
 			foreach (T element in source) func(element);
 			return source;
@@ -314,6 +314,37 @@ namespace MyBox
 				return default(T);
 			}
 			return source.Aggregate((e, n) => selector(e).CompareTo(selector(n)) < 0 ? e : n);
+		}
+
+		/// <summary>
+		/// Convert a single element into an enumerable with the source as the
+		/// single element.
+		/// </summary>
+		public static IEnumerable<T> AsEnumerable<T>(this T source) =>
+			Enumerable.Empty<T>().Append(source);
+
+		/// <summary>
+		/// First index of an item that matches a predicate.
+		/// </summary>
+		public static int FirstIndex<T>(this IList<T> source, Predicate<T> predicate)
+		{
+			for (int i = 0; i < source.Count; ++i)
+			{
+				if (predicate(source[i])) return i;
+			}
+			return -1;
+		}
+
+		/// <summary>
+		/// Last index of an item that matches a predicate.
+		/// </summary>
+		public static int LastIndex<T>(this IList<T> source, Predicate<T> predicate)
+		{
+			for (int i = source.Count - 1; i >=0; --i)
+			{
+				if (predicate(source[i])) return i;
+			}
+			return -1;
 		}
 	}
 }


### PR DESCRIPTION
`AsEnumerable`: This turns a single element into an `IEnumerable`. I originally created this to pass a single element into LINQ's `Except`, but then i realize it could meet many more general use cases so I added it in.

`FirstIndex`/`LastIndex`: `List`'s built-in `IndexOf` method only supports finding the first index of a matching element, vice versa for its `LastIndexOf`. But sometimes we have searching condition more sophisticated than that. `FirstIndex`/`LastIndex` were created to meet that use case. It's basically LINQ's `First` and `Last` methods but returns the index number instead. Note that these methods take in an `IList` as source and .Net's raw array technically implements this interface.

`ForEach`: A minor revision. I removed the null/empty check since I found that the null/empty check will cause a duplication of the first element when called on a collection generated by `Enumerable.Range`. The null/empty check will also cause a duplicated loop of the whole collection if I call `Enumerable.Range`, `Select`, `ForEach` and `ToList` in that order.