### PR TITLE
Add some extension methods round 8

### DIFF
--- a/Extensions/MyAlgorithms.cs
+++ b/Extensions/MyAlgorithms.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEngine.Events;
 
 namespace MyBox
 {
@@ -45,6 +46,88 @@ namespace MyBox
 		{
 			function(argument);
 			return argument;
+		}
+
+		/// <summary>
+		/// Adds a listener that executes only once to the UnityEvent.
+		/// </summary>
+		public static UnityEvent Once(this UnityEvent source, UnityAction action)
+		{
+			UnityAction wrapperAction = null;
+			wrapperAction = () =>
+			{
+				source.RemoveListener(wrapperAction);
+				action();
+			};
+			source.AddListener(wrapperAction);
+			return source;
+		}
+
+		/// <summary>
+		/// Adds a listener that executes only once to the UnityEvent.
+		/// </summary>
+		public static UnityEvent<T> Once<T>(this UnityEvent<T> source,
+			UnityAction<T> action)
+		{
+			UnityAction<T> wrapperAction = null;
+			wrapperAction = p =>
+			{
+				source.RemoveListener(wrapperAction);
+				action(p);
+			};
+			source.AddListener(wrapperAction);
+			return source;
+		}
+
+		/// <summary>
+		/// Adds a listener that executes only once to the UnityEvent.
+		/// </summary>
+		public static UnityEvent<T0, T1> Once<T0, T1>(
+			this UnityEvent<T0, T1> source,
+			UnityAction<T0, T1> action)
+		{
+			UnityAction<T0, T1> wrapperAction = null;
+			wrapperAction = (p0, p1) =>
+			{
+				source.RemoveListener(wrapperAction);
+				action(p0, p1);
+			};
+			source.AddListener(wrapperAction);
+			return source;
+		}
+
+		/// <summary>
+		/// Adds a listener that executes only once to the UnityEvent.
+		/// </summary>
+		public static UnityEvent<T0, T1, T2> Once<T0, T1, T2>(
+			this UnityEvent<T0, T1, T2> source,
+			UnityAction<T0, T1, T2> action)
+		{
+			UnityAction<T0, T1, T2> wrapperAction = null;
+			wrapperAction = (p0, p1, p2) =>
+			{
+				source.RemoveListener(wrapperAction);
+				action(p0, p1, p2);
+			};
+			source.AddListener(wrapperAction);
+			return source;
+		}
+
+		/// <summary>
+		/// Adds a listener that executes only once to the UnityEvent.
+		/// </summary>
+		public static UnityEvent<T0, T1, T2, T3> Once<T0, T1, T2, T3>(
+			this UnityEvent<T0, T1, T2, T3> source,
+			UnityAction<T0, T1, T2, T3> action)
+		{
+			UnityAction<T0, T1, T2, T3> wrapperAction = null;
+			wrapperAction = (p0, p1, p2, p3) =>
+			{
+				source.RemoveListener(wrapperAction);
+				action(p0, p1, p2, p3);
+			};
+			source.AddListener(wrapperAction);
+			return source;
 		}
 	}
 }

--- a/Extensions/MyCollections.cs
+++ b/Extensions/MyCollections.cs
@@ -283,6 +283,30 @@ namespace MyBox
 		}
 
 		/// <summary>
+		/// Performs an action on each element of a collection with its index
+		/// passed along.
+		/// </summary>
+		public static IEnumerable<T> ForEach<T>(this IEnumerable<T> source,
+			System.Action<T, int> action)
+		{
+			int index = 0;
+			foreach (T element in source) { action(element, index); ++index; }
+			return source;
+		}
+
+		/// <summary>
+		/// Performs an action on each element of a collection with its index
+		/// passed along.
+		/// </summary>
+		public static IEnumerable<T> ForEach<T, R>(this IEnumerable<T> source,
+			Func<T, int, R> func)
+		{
+			int index = 0;
+			foreach (T element in source) { func(element, index); ++index; }
+			return source;
+		}
+
+		/// <summary>
 		/// Find the element of a collection that has the highest selected value.
 		/// </summary>
 		public static T MaxBy<T, S>(this IEnumerable<T> source, Func<T, S> selector)

--- a/Extensions/MyColor.cs
+++ b/Extensions/MyColor.cs
@@ -53,10 +53,9 @@ namespace MyBox
 		/// </summary>
 		public static string ToHex(this Color color)
 		{
-			return string.Format("#{0:X2}{1:X2}{2:X2}", (int) (color.r * 255), (int) (color.g * 255), (int) (color.b * 255));
+			return string.Format("#{0:X2}{1:X2}{2:X2}", (int)(color.r * 255), (int)(color.g * 255), (int)(color.b * 255));
 		}
 
-		
 		private const float LightOffset = 0.0625f;
 		private const float DarkerFactor = 0.9f;
 		/// <summary>
@@ -87,7 +86,6 @@ namespace MyBox
 				color.a);
 		}
 
-		
 		/// <summary>
 		/// Brightness offset with 1 is brightest and -1 is darkest
 		/// </summary>
@@ -98,6 +96,17 @@ namespace MyBox
 				color.g + offset,
 				color.b + offset,
 				color.a);
+		}
+
+		/// <summary>
+		/// Converts a HTML color string into UnityEngine.Color. See
+		/// UnityEngine.ColorUtility.TryParseHtmlString for conversion conditions.
+		/// </summary>
+		public static Color ToUnityColor(this string source)
+		{
+			Color res;
+			ColorUtility.TryParseHtmlString(source, out res);
+			return res;
 		}
 	}
 }


### PR DESCRIPTION
`ToUnityColor`: Unity's builtin way to convert strings to UnityEngine.Color is a bit verbose. This methods turns
```
Color color;
ColorUtility.TryParseHtmlString("#40A9F0", out color);
BackgroundImage.color = color;
```
into `BackgroundImage.color = "#40A9F0".ToUnityColor();`

`ForEach`: There is now an overload of `ForEach` that functions similarly to its JavaScript counterpart - that is, passing along the element's index.

`Once`: Similarly to NodeJS's `EventEmitter.once`, this extension method registers a listener that only executes once after being added to `UnityEvent`. There's an overload for each variant of `UnityEvent`. I have yet to figure out a clean way to remove an `Once`d listener from the `UnityEvent` before it has the chance to execute, but that's likely to be a very niche use-case anyway.