### PR TITLE
OverrideLabelAttribute

### DIFF
--- a/Attributes/OverrideLabelAttribute.cs
+++ b/Attributes/OverrideLabelAttribute.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace MyBox
+{
+	public class OverrideLabelAttribute : PropertyAttribute
+	{
+		public string NewName;
+
+		public OverrideLabelAttribute(string newName) => NewName = newName;
+	}
+
+#if UNITY_EDITOR
+	namespace Internal
+	{
+		using UnityEditor;
+
+		[CustomPropertyDrawer(typeof(OverrideLabelAttribute))]
+		public class OverrideLabelDrawer : PropertyDrawer
+		{
+			public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+			{
+				label.text = (attribute as OverrideLabelAttribute).NewName;
+				EditorGUI.PropertyField(position, property, label);
+			}
+		}
+	}
+#endif
+}

--- a/Attributes/OverrideLabelAttribute.cs
+++ b/Attributes/OverrideLabelAttribute.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace MyBox
 {

--- a/Attributes/OverrideLabelAttribute.cs.meta
+++ b/Attributes/OverrideLabelAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8a3118b2fddf33042bce8519708bf318
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This is a simple attribute that lets you give a field a different name on the Inspector.

I guess I'll leave the documentation of this attribute to you, but I'd like the documentation to give notice of 3 things:

- This can be used to get around the [name mangling issue of an auto-implemented property's backing field, which will remain unfixed in Unity 2019 or below](https://forum.unity.com/threads/c-7-3-field-serializefield-support.573988/). This will appear normally under Unity 2019:
```
[field: SerializeField, OverrideLabel("Value")]
public int Value { get; set; } = 0;
```
- This attribute is incompatible with `MyBox.ReadOnly`.
- This attribute is compatible with `MyBox.AutoProperty` **only if it is placed before `MyBox.AutoProperty`**.