### PR TITLE
Expand AutoPropertyAttribute to multiple modes

### DIFF
--- a/Attributes/AutoPropertyAttribute.cs
+++ b/Attributes/AutoPropertyAttribute.cs
@@ -61,17 +61,24 @@ namespace MyBox.Internal
 					.GetComponentsInParent(property.Field.FieldType.GetElementType(), true),
 				[AutoPropertyMode.Scene] = property => Object
 					.FindObjectsOfType(property.Field.FieldType.GetElementType()),
-				[AutoPropertyMode.Asset] = property => Resources
-					.FindObjectsOfTypeAll(property.Field.FieldType.GetElementType())
-					.Where(obj =>
-					{
-						var prefabType = PrefabUtility.GetPrefabAssetType(obj);
-						return prefabType == PrefabAssetType.Regular
-							|| prefabType == PrefabAssetType.Model;
-					})
-					.ToArray(),
-				[AutoPropertyMode.Any] = property => Resources
-					.FindObjectsOfTypeAll(property.Field.FieldType.GetElementType())
+				[AutoPropertyMode.Asset] = property =>
+				{
+					MyEditor.LoadAllAssetsOfType(property.Field.FieldType.GetElementType());
+					return Resources.FindObjectsOfTypeAll(property.Field.FieldType.GetElementType())
+						.Where(obj =>
+						{
+							var prefabType = PrefabUtility.GetPrefabAssetType(obj);
+							return prefabType == PrefabAssetType.Regular
+								|| prefabType == PrefabAssetType.Model;
+						})
+						.ToArray();
+				},
+				[AutoPropertyMode.Any] = property =>
+				{
+					MyEditor.LoadAllAssetsOfType(property.Field.FieldType.GetElementType());
+					return Resources
+						.FindObjectsOfTypeAll(property.Field.FieldType.GetElementType());
+				}
 			};
 
 		static readonly Dictionary<int, Func<MyEditor.ComponentField, Object>> SingularObjectGetters
@@ -84,18 +91,24 @@ namespace MyBox.Internal
 					.FirstOrDefault(),
 				[AutoPropertyMode.Scene] = property => Object
 					.FindObjectOfType(property.Field.FieldType),
-				[AutoPropertyMode.Asset] = property => Resources
-					.FindObjectsOfTypeAll(property.Field.FieldType)
-					.Where(obj =>
-					{
-						var prefabType = PrefabUtility.GetPrefabAssetType(obj);
-						return prefabType == PrefabAssetType.Regular
-							|| prefabType == PrefabAssetType.Model;
-					})
-					.FirstOrDefault(),
-				[AutoPropertyMode.Any] = property => Resources
-					.FindObjectsOfTypeAll(property.Field.FieldType)
-					.FirstOrDefault()
+				[AutoPropertyMode.Asset] = property =>
+				{
+					MyEditor.LoadAllAssetsOfType(property.Field.FieldType);
+					return Resources.FindObjectsOfTypeAll(property.Field.FieldType)
+						.Where(obj =>
+						{
+							var prefabType = PrefabUtility.GetPrefabAssetType(obj);
+							return prefabType == PrefabAssetType.Regular
+								|| prefabType == PrefabAssetType.Model;
+						})
+						.FirstOrDefault();
+				},
+				[AutoPropertyMode.Any] = property =>
+				{
+					MyEditor.LoadAllAssetsOfType(property.Field.FieldType);
+					return Resources.FindObjectsOfTypeAll(property.Field.FieldType)
+						.FirstOrDefault();
+				}
 			};
 
 		static AutoPropertyHandler()

--- a/Attributes/AutoPropertyAttribute.cs
+++ b/Attributes/AutoPropertyAttribute.cs
@@ -19,10 +19,26 @@ namespace MyBox
 
 	public class AutoPropertyMode
 	{
+		/// <summary>
+		/// Search for Components from this GO or its children.
+		/// </summary>
 		public const int Children = 0;
+		/// <summary>
+		/// Search for Components from this GO or its parents.
+		/// </summary>
 		public const int Parent = 1;
+		/// <summary>
+		/// Search for Components from this GO's current scene.
+		/// </summary>
 		public const int Scene = 2;
+		/// <summary>
+		/// Search for Objects from this project's asset folder.
+		/// </summary>
 		public const int Asset = 3;
+		/// <summary>
+		/// Search for Objects from anywhere in the project.
+		/// Combines the results of Scene and Asset modes.
+		/// </summary>
 		public const int Any = 4;
 	}
 }

--- a/Extensions/EditorExtensions/MyEditor.cs
+++ b/Extensions/EditorExtensions/MyEditor.cs
@@ -267,6 +267,13 @@ namespace MyBox.EditorTools
 
 		#endregion
 
+		/// <summary>
+		/// Force Unity Editor to load lazily-loaded types such as ScriptableObject.
+		/// </summary>
+		public static void LoadAllAssetsOfType(Type type) => AssetDatabase
+			.FindAssets($"t:{type.FullName}")
+			.Select(AssetDatabase.GUIDToAssetPath)
+			.ForEach(p => AssetDatabase.LoadAssetAtPath(p, type));
 
 		public static void CopyToClipboard(string text)
 		{


### PR DESCRIPTION
This will expand the capability of `AutoPropertyAttribute` to search for objects from different source other than self and children.

Parent mode will try to search for objects in self and parents.
Scene mode will try to search for objects in the current scene.
Asset mode will try to search for objects in the project assets.
Any mode combines the results of Scene and Asset modes.

Asset mode can be used to auto-assign Scriptable Objects that are effectively Singleton Manager objects without resorting to the error-prone Singleton anti-pattern.

Interestingly when you pass a Scriptable Object into `PrefabUtility.GetPrefabAssetType`, it will return `PrefabAssetType.Model`.

This PR will effectively close issue #83 by using the Scene mode for `AutoProperty`.