### PR TITLE
Fixed Issue #103, ToCamelCase in MyString.cs. Added '_' and '-' as delimiter

### DIFF
--- a/Extensions/MyString.cs
+++ b/Extensions/MyString.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.RegularExpressions;
 using System;
+using System.Globalization;
 using UnityEngine;
 
 namespace MyBox
@@ -9,7 +10,12 @@ namespace MyBox
 		/// <summary>
 		/// "Camel case string" => "CamelCaseString" 
 		/// </summary>
-		public static string ToCamelCase(this string message) => Regex.Replace(message, "([a-z](?=[A-Z])|[A-Z](?=[A-Z][a-z]))", "$1 ").Trim();
+		public static string ToCamelCase(this string message) {
+			message = message.Replace("-", " ").Replace("_", " ");
+			message = CultureInfo.InvariantCulture.TextInfo.ToTitleCase(message);
+			message = message.Replace(" ", "");
+			return message;
+		}
 
 		/// <summary>
 		/// "CamelCaseString" => "Camel Case String"


### PR DESCRIPTION
MyString.ToCamelCase now works as intended. 
It doesn't use regex anymore, instead it makes use of the CultureInfo/TextInfo `ToTitleCase()` method in the System.Globalization namespace.
It also adds underscore `_` and hypens `-` as possible delimiters.
    

Test Cases:

    my_camel-case test -> MyCamelCaseTest
    My caMel caSE_test -> MyCamelCaseTest

This PR effectively fixes issue #103 