### PR TITLE
Redirect "View documentation" link in UPM interface to MyBox's wiki

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.physics2d": "1.0.0"
 },
+"documentationUrl": "https://github.com/Deadcows/MyBox/wiki",
 
 "keywords": ["attributes", "extensions", "editor tools"],
 "author": { "name" : "Andrew Rumak",


### PR DESCRIPTION
Exactly what it says on the tin. I filled in [this package property](https://docs.unity3d.com/2021.2/Documentation/ScriptReference/PackageManager.PackageInfo-documentationUrl.html) so that clicking on the "View documentation link in UPM interface will open MyBox's wiki.