### PR TITLE
Fix build compilation warnings

### DIFF
--- a/Attributes/MaxValueAttribute.cs
+++ b/Attributes/MaxValueAttribute.cs
@@ -13,7 +13,9 @@ namespace MyBox
 		private readonly float _y;
 		private readonly float _z;
 
+#if UNITY_EDITOR
 		private readonly bool _vectorValuesSet;
+#endif
 
 		public MaxValueAttribute(float value)
 		{
@@ -25,7 +27,9 @@ namespace MyBox
 			_x = x;
 			_y = y;
 			_z = z;
+#if UNITY_EDITOR
 			_vectorValuesSet = true;
+#endif
 		}
 
 #if UNITY_EDITOR

--- a/Attributes/MinValueAttribute.cs
+++ b/Attributes/MinValueAttribute.cs
@@ -13,7 +13,9 @@ namespace MyBox
 		private readonly float _y;
 		private readonly float _z;
 
+#if UNITY_EDITOR
 		private readonly bool _vectorValuesSet;
+#endif
 
 		public MinValueAttribute(float value)
 		{
@@ -25,7 +27,9 @@ namespace MyBox
 			_x = x;
 			_y = y;
 			_z = z;
+#if UNITY_EDITOR
 			_vectorValuesSet = true;
+#endif
 		}
 
 #if UNITY_EDITOR


### PR DESCRIPTION
### Summary

Hi,

When building a project which uses `com.domybest.mybox` there are following compilation warnings:
```
Packages\com.domybest.mybox\Attributes\MaxValueAttribute.cs(16,25): warning CS0414: The field 'MaxValueAttribute._vectorValuesSet' is assigned but its value is never used
Packages\com.domybest.mybox\Attributes\MinValueAttribute.cs(16,25): warning CS0414: The field 'MinValueAttribute._vectorValuesSet' is assigned but its value is never used
```

They are caused by `_vectorValuesSet` value is used only when `UNITY_EDITOR` define is set which does not happen for the build.

Fixing the warnings by always guarding `_vectorValuesSet` with `UNITY_EDITOR` define.

### How to test
Checkout target branch and build Unity project for any platform. Observe warnings in the Unity editor console after the build is finished. Checkout source branch and build Unity project for any platform. Observe no warnings in the console.