### PR TITLE
Add CharacterRangeAttribute

### DIFF
--- a/Attributes/CharacterRangeAttribute.cs
+++ b/Attributes/CharacterRangeAttribute.cs
@@ -1,0 +1,52 @@
+﻿using UnityEngine;
+
+namespace MyBox
+{
+	/// <summary>
+	/// Validate a string field to only allow or disallow a set of pre-defined
+	/// characters on typing.
+	/// </summary>
+	public class CharacterRangeAttribute : PropertyAttribute
+	{
+		public readonly string Characters;
+		public readonly bool AllowMode;
+
+		public CharacterRangeAttribute(string characters, bool allowMode = true)
+		{ Characters = characters; AllowMode = allowMode; }
+	}
+}
+
+#if UNITY_EDITOR
+namespace MyBox.Internal
+{
+	using UnityEditor;
+	using EditorTools;
+	using System.Linq;
+
+	[CustomPropertyDrawer(typeof(CharacterRangeAttribute))]
+	public class CharacterRangeAttributeDrawer : PropertyDrawer
+	{
+		public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+		{
+			if (property.propertyType != SerializedPropertyType.String)
+			{
+				MyGUI.DrawColouredRect(position, MyGUI.Colors.Red);
+				EditorGUI.LabelField(position, new GUIContent("", "[CharacterRangeAttribute] used with non-string property"));
+			}
+			else
+			{
+				var crAttribute = attribute as CharacterRangeAttribute;
+				var disallowedCharacters = property.stringValue.Distinct()
+					.Where(c => crAttribute.Characters.Contains(c)
+						^ crAttribute.AllowMode);
+				property.stringValue = disallowedCharacters.Aggregate(
+					property.stringValue,
+					(p, c) => p.Replace(c.ToString(), ""));
+				property.serializedObject.ApplyModifiedProperties();
+			}
+
+			EditorGUI.PropertyField(position, property, label, true);
+		}
+	}
+}
+#endif

--- a/Attributes/CharacterRangeAttribute.cs.meta
+++ b/Attributes/CharacterRangeAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: add63a4947a64f2428030472426ecba4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
`CharacterRangeAttribute` will validate a string field upon finish typing to allow or disallow a set of characters passed as string.

By default, it runs in an "Allow Mode" (can be thought of as passing in a whitelist of characters), but accepts a 2nd argument to run in a "Disallow Mode" (can be thought of as passing in a blacklist of characters).

This will effectively close issue #82.