### PR TITLE
Fix AutoPropertyAttribute not detecting prefabs without selecting them in Project tab at least once per Editor launch

### DIFF
--- a/Attributes/AutoPropertyAttribute.cs
+++ b/Attributes/AutoPropertyAttribute.cs
@@ -79,11 +79,13 @@ namespace MyBox.Internal
 				[AutoPropertyMode.Asset] = property =>
 				{
 					MyEditor.LoadAllAssetsOfType(property.Field.FieldType.GetElementType());
+					MyEditor.LoadAllAssetsOfType("Prefab");
 					return Resources.FindObjectsOfTypeAll(property.Field.FieldType.GetElementType()).Where(AssetDatabase.Contains).ToArray();
 				},
 				[AutoPropertyMode.Any] = property =>
 				{
 					MyEditor.LoadAllAssetsOfType(property.Field.FieldType.GetElementType());
+					MyEditor.LoadAllAssetsOfType("Prefab");
 					return Resources.FindObjectsOfTypeAll(property.Field.FieldType.GetElementType());
 				}
 			};

--- a/Attributes/AutoPropertyAttribute.cs
+++ b/Attributes/AutoPropertyAttribute.cs
@@ -101,11 +101,13 @@ namespace MyBox.Internal
 				[AutoPropertyMode.Asset] = property =>
 				{
 					MyEditor.LoadAllAssetsOfType(property.Field.FieldType);
+					MyEditor.LoadAllAssetsOfType("Prefab");
 					return Resources.FindObjectsOfTypeAll(property.Field.FieldType).FirstOrDefault(AssetDatabase.Contains);
 				},
 				[AutoPropertyMode.Any] = property =>
 				{
 					MyEditor.LoadAllAssetsOfType(property.Field.FieldType);
+					MyEditor.LoadAllAssetsOfType("Prefab");
 					return Resources.FindObjectsOfTypeAll(property.Field.FieldType)
 						.FirstOrDefault();
 				}
@@ -170,7 +172,7 @@ namespace MyBox.Internal
 				}
 			}
 
-			Debug.LogError($"{property.Component.name} caused: {property.Field.Name} is failed to Auto Assign property. No match", 
+			Debug.LogError($"{property.Component.name} caused: {property.Field.Name} is failed to Auto Assign property. No match",
 				property.Component.gameObject);
 		}
 	}

--- a/Extensions/EditorExtensions/MyEditor.cs
+++ b/Extensions/EditorExtensions/MyEditor.cs
@@ -275,6 +275,14 @@ namespace MyBox.EditorTools
 			.Select(AssetDatabase.GUIDToAssetPath)
 			.ForEach(p => AssetDatabase.LoadAssetAtPath(p, type));
 
+		/// <summary>
+		/// Force Unity Editor to load lazily-loaded types such as ScriptableObject.
+		/// </summary>
+		public static void LoadAllAssetsOfType(string typeName) => AssetDatabase
+			.FindAssets($"t:{typeName}")
+			.Select(AssetDatabase.GUIDToAssetPath)
+			.ForEach(p => AssetDatabase.LoadAssetAtPath(p, typeof(UnityEngine.Object)));
+
 		public static void CopyToClipboard(string text)
 		{
 			TextEditor te = new TextEditor();


### PR DESCRIPTION
Exactly what it says on the tin. Prefabs in Unity can only be detected by `AssetDatabase.FindAssets` using the search term "t:Prefab".