### PR TITLE
Add some extension methods round 9

### DIFF
--- a/Extensions/MyAlgorithms.cs
+++ b/Extensions/MyAlgorithms.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UnityEngine.Events;
+using UnityEngine;
 
 namespace MyBox
 {
@@ -128,6 +129,32 @@ namespace MyBox
 			};
 			source.AddListener(wrapperAction);
 			return source;
+		}
+
+		/// <summary>
+		/// Sets the state of the source enum, chosen by the 1-bits in the specified
+		/// bit mask.
+		/// </summary>
+		public static RigidbodyConstraints BitwiseToggle(
+			this RigidbodyConstraints source,
+			RigidbodyConstraints bitMask,
+			bool state)
+		{
+			if (state) return source | bitMask;
+			else return source & ~bitMask;
+		}
+
+		/// <summary>
+		/// Sets the state of the source enum, chosen by the 1-bits in the specified
+		/// bit mask.
+		/// </summary>
+		public static RigidbodyConstraints2D BitwiseToggle(
+			this RigidbodyConstraints2D source,
+			RigidbodyConstraints2D bitMask,
+			bool state)
+		{
+			if (state) return source | bitMask;
+			else return source & ~bitMask;
 		}
 	}
 }

--- a/Extensions/MyCollections.cs
+++ b/Extensions/MyCollections.cs
@@ -422,5 +422,78 @@ namespace MyBox
 		public static T GetWeightedRandom<T>(this IEnumerable<T> source,
 			Func<T, double> weightSelector) =>
 			source.ElementAt(source.GetWeightedRandomIndex(weightSelector));
+
+		/// <summary>
+		/// Returns an array of elements with the length equal to the source
+		/// value.
+		/// </summary>
+		public static T[] AsLengthMakeArray<T>(this int source) => new T[source];
+
+		/// <summary>
+		/// Fills a collection with values generated using a factory function that
+		/// passes along their index numbers.
+		/// </summary>
+		public static IList<T> FillBy<T>(this IList<T> source,
+			Func<int, T> valueFactory)
+		{
+			for (int i = 0; i < source.Count; ++i) source[i] = valueFactory(i);
+			return source;
+		}
+
+		/// <summary>
+		/// Fills an array with values generated using a factory function that
+		/// passes along their index numbers.
+		/// </summary>
+		public static T[] FillBy<T>(this T[] source,
+			Func<int, T> valueFactory)
+		{
+			for (int i = 0; i < source.Length; ++i) source[i] = valueFactory(i);
+			return source;
+		}
+
+		/// <summary>
+		/// Randomly samples a non-repeating number of elements from the source
+		/// collection.
+		/// </summary>
+		public static T[] ExclusiveSample<T>(this IList<T> source,
+			int sampleNumber)
+		{
+			var results = new T[sampleNumber];
+			int resultIndex = 0;
+			for (int i = 0; i < source.Count && resultIndex < sampleNumber; ++i)
+			{
+				var probability = (double)(sampleNumber - resultIndex)
+					/ (source.Count - i);
+				if (MyCommonConstants.SystemRandom.NextDouble() < probability)
+				{ results[resultIndex] = source[i]; ++resultIndex; }
+			}
+			return results;
+		}
+
+		/// <summary>
+		/// Swaps 2 elements at the specified index positions in place.
+		/// </summary>
+		public static IList<T> SwapInPlace<T>(this IList<T> source,
+			int index1,
+			int index2)
+		{
+			var e1 = source[index1];
+			source[index1] = source[index2];
+			source[index2] = e1;
+			return source;
+		}
+
+		/// <summary>
+		/// Shuffles a collection in place using the Knuth algorithm.
+		/// </summary>
+		public static IList<T> ShuffleKnuth<T>(this IList<T> source)
+		{
+			for (int i = 0; i < source.Count - 1; ++i)
+			{
+				var indexToSwap = MyCommonConstants.SystemRandom.Next(i, source.Count);
+				source.SwapInPlace(i, indexToSwap);
+			}
+			return source;
+		}
 	}
 }

--- a/Extensions/MyCollections.cs
+++ b/Extensions/MyCollections.cs
@@ -458,6 +458,8 @@ namespace MyBox
 		public static T[] ExclusiveSample<T>(this IList<T> source,
 			int sampleNumber)
 		{
+			if (sampleNumber > source.Count)
+				throw new ArgumentOutOfRangeException("Cannot sample more elements than what the source collection contains");
 			var results = new T[sampleNumber];
 			int resultIndex = 0;
 			for (int i = 0; i < source.Count && resultIndex < sampleNumber; ++i)

--- a/Extensions/MyCollections.cs
+++ b/Extensions/MyCollections.cs
@@ -492,7 +492,7 @@ namespace MyBox
 		{
 			for (int i = 0; i < source.Count - 1; ++i)
 			{
-				var indexToSwap = MyCommonConstants.SystemRandom.Next(i, source.Count);
+				var indexToSwap = UnityEngine.Random.Range(i, source.Count);
 				source.SwapInPlace(i, indexToSwap);
 			}
 			return source;

--- a/Extensions/MyPhysics.cs
+++ b/Extensions/MyPhysics.cs
@@ -1,0 +1,31 @@
+﻿using UnityEngine;
+
+namespace MyBox
+{
+	public static partial class MyPhysics
+	{
+		/// <summary>
+		/// Sets the state of constraints for the source Rigidbody.
+		/// </summary>
+		public static Rigidbody ToggleConstraints(this Rigidbody source,
+			RigidbodyConstraints constraints,
+			bool state)
+		{
+			if (state) source.constraints = source.constraints | constraints;
+			else source.constraints = source.constraints & ~constraints;
+			return source;
+		}
+
+		/// <summary>
+		/// Sets the state of constraints for the source Rigidbody2D.
+		/// </summary>
+		public static Rigidbody2D ToggleConstraints(this Rigidbody2D source,
+			RigidbodyConstraints2D constraints,
+			bool state)
+		{
+			if (state) source.constraints = source.constraints | constraints;
+			else source.constraints = source.constraints & ~constraints;
+			return source;
+		}
+	}
+}

--- a/Extensions/MyPhysics.cs
+++ b/Extensions/MyPhysics.cs
@@ -11,8 +11,7 @@ namespace MyBox
 			RigidbodyConstraints constraints,
 			bool state)
 		{
-			if (state) source.constraints = source.constraints | constraints;
-			else source.constraints = source.constraints & ~constraints;
+			source.constraints = source.constraints.BitwiseToggle(constraints, state);
 			return source;
 		}
 
@@ -23,8 +22,7 @@ namespace MyBox
 			RigidbodyConstraints2D constraints,
 			bool state)
 		{
-			if (state) source.constraints = source.constraints | constraints;
-			else source.constraints = source.constraints & ~constraints;
+			source.constraints = source.constraints.BitwiseToggle(constraints, state);
 			return source;
 		}
 	}

--- a/Extensions/MyPhysics.cs.meta
+++ b/Extensions/MyPhysics.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 930598581d4ea624c9cb11353c2f80c2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tools/Undone/MyPhysics.cs
+++ b/Tools/Undone/MyPhysics.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 namespace MyBox
 {
-	public class MyPhysics
+	public static partial class MyPhysics
 	{
 		public static readonly RaycastHit2D[] Hits = new RaycastHit2D[20];
 		public static readonly Collider2D[] Colliders = new Collider2D[20];


### PR DESCRIPTION
The extension methods this round were added because I encountered use-cases for them across multiple projects, and I'm tired of copy-pasting them around.

`AsLengthMakeArray` and `FillBy`: This was created because while `Enumerable.Range(0, length).Select(i => { [...] }).ToArray()` is succint, it creates a performance problem with 2 array allocations, the first one by calling `Enumerable.Range` is just for the purpose of counting index number and immediately discarded. These 2 methods resolve that performance issue on top of being able to continue a call chain that results in an integer number without assigning it to some variable and thinking up a name for it. We can now write `length.AsLengthMakeArray<ElementType>().FillBy(i => { [...] })`.

An overload for `FillBy` is provided to preserve the array type at the output of the call chain.

I'm aware that [`Array.Fill`](https://docs.microsoft.com/en-us/dotnet/api/system.array.fill?view=net-5.0) exists but I wrote these 2 methods because 1. Unity devs are stuck with .NET Standard 2.0 for LTS at the current moment and 2. `Array.Fill` does not take in a factory function, which is what these method are for.

With that said, I have some hesitation about `AsLengthMakeArray` after the fact. `length.AsLengthMakeArray<ElementType>()` technically can be written as `length.Pipe(l => new ElementType[l])`, thus making `AsLengthMakeArray` potentially unnecessary bloat. Feel free to remove it from this PR if you don't want it.

`SwapInPlace`: Just a common operation of in-place swap of 2 elements using their index numbers. This always takes 3 lines without an extension method. It's all in 1 line now.

`ShuffleKnuth`: This is an implementation of Knuth shuffle aka Fisher-Yates shuffle. To keep it brief, the naive shuffle implementation `collection.OrderBy(_ => rng.Next())` has a complexity of O(n log(n)). Knuth shuffle keeps the complexity at O(n).

`ExclusiveSample`: Randomly taking `n` repeatable number of elements from a list collection is pretty straight-forward, just a for loop `n` number of times. Randomly taking `n` number of exclusive (non-repeating) number of elements however, requires some consideration. Shuffling a list naively and then `.Take(sampleNumber)` has a complexity of O(n log(n)). Knuth-shuffling, while keeping the complexity at O(n), always iterates through the whole collection to perform a shuffle before we `.Take` anything. This implementation of exclusively sampling only has O(n) as the worst-case scenario because it would stop iterating the collection as soon as it samples enough.

`ExclusiveSample` will also effectively supercede the existing `GetRandomCollection` method in `MyCollections`. At a glance, `GetRandomCollection` appears to be a faulty implementation and should be deprecated if not outright removed. It's not getting n random elements from a source collection. What `GetRandomCollection` is actually doing is taking the _first_ n elements of the source collection and shuffle them.

`ToggleConstraints`: The syntax for turning Rigidbody/Rigidbody2D constraints on and off is unintuitive and makes you stop to think about bitwise logic, especially when figuring out how to turn off a constraint. This extension method provides a more straightforward syntax, enabling you to use a boolean value to toggle the state of Rigidbody/Rigidbody2D constraints.

The class for the last method is `MyPhysics`, which created a potential naming conflict with an existing `MyPhysics` class under Tools/Undone. I made them both static partial to resolve this naming conflict.