### PR TITLE
Fix AutoProperty and MustBeAssigned not working for fields of ScriptableObjects

### DIFF
--- a/Attributes/AutoPropertyAttribute.cs
+++ b/Attributes/AutoPropertyAttribute.cs
@@ -93,8 +93,7 @@ namespace MyBox.Internal
 					?.GetComponentsInParent(property.Field.FieldType, true)
 					.FirstOrDefault(),
 				[AutoPropertyMode.Scene] = property => MyEditor
-					.GetAllComponentsInSceneOf(property.Context,
-						property.Field.FieldType.GetElementType())
+					.GetAllComponentsInSceneOf(property.Context, property.Field.FieldType)
 					.FirstOrDefault(),
 				[AutoPropertyMode.Asset] = property => Resources
 					.FindObjectsOfTypeAll(property.Field.FieldType)

--- a/Attributes/AutoPropertyAttribute.cs
+++ b/Attributes/AutoPropertyAttribute.cs
@@ -113,23 +113,13 @@ namespace MyBox.Internal
 			PrefabStage.prefabStageOpened += stage => CheckComponentsInPrefab(stage.prefabContentsRoot);
 		}
 
-		private static void CheckAssets()
-		{
-			var autoProperties = MyEditor.GetFieldsWithAttribute<AutoPropertyAttribute>();
-			for (var i = 0; i < autoProperties.Length; i++)
-			{
-				FillProperty(autoProperties[i]);
-			}
-		}
+		private static void CheckAssets() => MyEditor
+			.GetFieldsWithAttribute<AutoPropertyAttribute>()
+			.ForEach(FillProperty);
 
-		private static void CheckComponentsInPrefab(GameObject prefab)
-		{
-			var autoProperties = MyEditor.GetFieldsWithAttribute<AutoPropertyAttribute>(prefab);
-			for (var i = 0; i < autoProperties.Length; i++)
-			{
-				FillProperty(autoProperties[i]);
-			}
-		}
+		private static void CheckComponentsInPrefab(GameObject prefab) => MyEditor
+			.GetFieldsWithAttribute<AutoPropertyAttribute>(prefab)
+			.ForEach(FillProperty);
 
 		private static void FillProperty(MyEditor.ObjectField property)
 		{

--- a/Attributes/AutoPropertyAttribute.cs
+++ b/Attributes/AutoPropertyAttribute.cs
@@ -76,18 +76,11 @@ namespace MyBox.Internal
 					?.GetComponentsInParent(property.Field.FieldType.GetElementType(), true),
 				[AutoPropertyMode.Scene] = property => Object
 					.FindObjectsOfType(property.Field.FieldType.GetElementType()),
-				[AutoPropertyMode.Asset] = property =>
-				{
-					MyEditor.LoadAllAssetsOfType(property.Field.FieldType.GetElementType());
-					MyEditor.LoadAllAssetsOfType("Prefab");
-					return Resources.FindObjectsOfTypeAll(property.Field.FieldType.GetElementType()).Where(AssetDatabase.Contains).ToArray();
-				},
-				[AutoPropertyMode.Any] = property =>
-				{
-					MyEditor.LoadAllAssetsOfType(property.Field.FieldType.GetElementType());
-					MyEditor.LoadAllAssetsOfType("Prefab");
-					return Resources.FindObjectsOfTypeAll(property.Field.FieldType.GetElementType());
-				}
+				[AutoPropertyMode.Asset] = property => Resources
+					.FindObjectsOfTypeAll(property.Field.FieldType.GetElementType())
+					.Where(AssetDatabase.Contains).ToArray(),
+				[AutoPropertyMode.Any] = property => Resources
+					.FindObjectsOfTypeAll(property.Field.FieldType.GetElementType())
 			};
 
 		private static readonly Dictionary<AutoPropertyMode, Func<MyEditor.ObjectField, Object>> SingularObjectGetters
@@ -100,19 +93,12 @@ namespace MyBox.Internal
 					.FirstOrDefault(),
 				[AutoPropertyMode.Scene] = property => Object
 					.FindObjectOfType(property.Field.FieldType),
-				[AutoPropertyMode.Asset] = property =>
-				{
-					MyEditor.LoadAllAssetsOfType(property.Field.FieldType);
-					MyEditor.LoadAllAssetsOfType("Prefab");
-					return Resources.FindObjectsOfTypeAll(property.Field.FieldType).FirstOrDefault(AssetDatabase.Contains);
-				},
-				[AutoPropertyMode.Any] = property =>
-				{
-					MyEditor.LoadAllAssetsOfType(property.Field.FieldType);
-					MyEditor.LoadAllAssetsOfType("Prefab");
-					return Resources.FindObjectsOfTypeAll(property.Field.FieldType)
-						.FirstOrDefault();
-				}
+				[AutoPropertyMode.Asset] = property => Resources
+					.FindObjectsOfTypeAll(property.Field.FieldType)
+					.FirstOrDefault(AssetDatabase.Contains),
+				[AutoPropertyMode.Any] = property => Resources
+					.FindObjectsOfTypeAll(property.Field.FieldType)
+					.FirstOrDefault()
 			};
 
 		static AutoPropertyHandler()
@@ -151,24 +137,24 @@ namespace MyBox.Internal
 
 			if (property.Field.FieldType.IsArray)
 			{
-				Object[] components = MultipleObjectsGetters[apAttribute.Mode].Invoke(property);
-				if (components != null && components.Length > 0)
+				var objects = MultipleObjectsGetters[apAttribute.Mode].Invoke(property);
+				if (objects != null && objects.Length > 0)
 				{
 					var serializedObject = new SerializedObject(property.Context);
 					var serializedProperty = serializedObject.FindProperty(property.Field.Name);
-					serializedProperty.ReplaceArray(components);
+					serializedProperty.ReplaceArray(objects);
 					serializedObject.ApplyModifiedProperties();
 					return;
 				}
 			}
 			else
 			{
-				var component = SingularObjectGetters[apAttribute.Mode].Invoke(property);
-				if (component != null)
+				var obj = SingularObjectGetters[apAttribute.Mode].Invoke(property);
+				if (obj != null)
 				{
 					var serializedObject = new SerializedObject(property.Context);
 					var serializedProperty = serializedObject.FindProperty(property.Field.Name);
-					serializedProperty.objectReferenceValue = component;
+					serializedProperty.objectReferenceValue = obj;
 					serializedObject.ApplyModifiedProperties();
 					return;
 				}

--- a/Attributes/AutoPropertyAttribute.cs
+++ b/Attributes/AutoPropertyAttribute.cs
@@ -107,13 +107,13 @@ namespace MyBox.Internal
 		static AutoPropertyHandler()
 		{
 			// this event is for GameObjects in the scene.
-			MyEditorEvents.OnSave += CheckComponentsInScene;
+			MyEditorEvents.OnSave += CheckAssets;
 			// this event is for prefabs saved in edit mode.
 			PrefabStage.prefabSaved += CheckComponentsInPrefab;
 			PrefabStage.prefabStageOpened += stage => CheckComponentsInPrefab(stage.prefabContentsRoot);
 		}
 
-		private static void CheckComponentsInScene()
+		private static void CheckAssets()
 		{
 			var autoProperties = MyEditor.GetFieldsWithAttribute<AutoPropertyAttribute>();
 			for (var i = 0; i < autoProperties.Length; i++)

--- a/Attributes/AutoPropertyAttribute.cs
+++ b/Attributes/AutoPropertyAttribute.cs
@@ -74,8 +74,9 @@ namespace MyBox.Internal
 					?.GetComponentsInChildren(property.Field.FieldType.GetElementType(), true),
 				[AutoPropertyMode.Parent] = property => property.Context.As<Component>()
 					?.GetComponentsInParent(property.Field.FieldType.GetElementType(), true),
-				[AutoPropertyMode.Scene] = property => Object
-					.FindObjectsOfType(property.Field.FieldType.GetElementType()),
+				[AutoPropertyMode.Scene] = property => MyEditor
+					.GetAllComponentsInSceneOf(property.Context,
+						property.Field.FieldType.GetElementType()).ToArray(),
 				[AutoPropertyMode.Asset] = property => Resources
 					.FindObjectsOfTypeAll(property.Field.FieldType.GetElementType())
 					.Where(AssetDatabase.Contains).ToArray(),
@@ -91,8 +92,10 @@ namespace MyBox.Internal
 				[AutoPropertyMode.Parent] = property => property.Context.As<Component>()
 					?.GetComponentsInParent(property.Field.FieldType, true)
 					.FirstOrDefault(),
-				[AutoPropertyMode.Scene] = property => Object
-					.FindObjectOfType(property.Field.FieldType),
+				[AutoPropertyMode.Scene] = property => MyEditor
+					.GetAllComponentsInSceneOf(property.Context,
+						property.Field.FieldType.GetElementType())
+					.FirstOrDefault(),
 				[AutoPropertyMode.Asset] = property => Resources
 					.FindObjectsOfTypeAll(property.Field.FieldType)
 					.FirstOrDefault(AssetDatabase.Contains),

--- a/Attributes/ConditionalFieldAttribute.cs
+++ b/Attributes/ConditionalFieldAttribute.cs
@@ -343,11 +343,11 @@ namespace MyBox.Internal
 
 		#region Behaviour Property Is Visible
 
-		public static bool BehaviourPropertyIsVisible(MonoBehaviour behaviour, string propertyName, ConditionalFieldAttribute appliedAttribute)
+		public static bool BehaviourPropertyIsVisible(UnityEngine.Object obj, string propertyName, ConditionalFieldAttribute appliedAttribute)
 		{
 			if (string.IsNullOrEmpty(appliedAttribute.FieldToCheck)) return true;
 
-			var so = new SerializedObject(behaviour);
+			var so = new SerializedObject(obj);
 			var property = so.FindProperty(propertyName);
 			var targetProperty = FindRelativeProperty(property, appliedAttribute.FieldToCheck);
 

--- a/Attributes/MustBeAssignedConditionalFieldExclude.cs
+++ b/Attributes/MustBeAssignedConditionalFieldExclude.cs
@@ -17,7 +17,7 @@ namespace MyBox.Internal
 		
 		private static readonly Type _conditionallyVisibleType = typeof(ConditionalFieldAttribute);
 		
-		private static bool ExcludeCheckIfConditionalFieldHidden(FieldInfo field, MonoBehaviour behaviour)
+		private static bool ExcludeCheckIfConditionalFieldHidden(FieldInfo field, UnityEngine.Object obj)
 		{
 			if (_conditionallyVisibleType == null) return false;
 			if (!field.IsDefined(_conditionallyVisibleType, false)) return false;
@@ -28,7 +28,7 @@ namespace MyBox.Internal
 				.SingleOrDefault();
 
 			return conditionalFieldAttribute != null &&
-			       !ConditionalFieldUtility.BehaviourPropertyIsVisible(behaviour, field.Name, conditionalFieldAttribute);
+			       !ConditionalFieldUtility.BehaviourPropertyIsVisible(obj, field.Name, conditionalFieldAttribute);
 		}
 	}
 }

--- a/Extensions/EditorExtensions/MyEditor.cs
+++ b/Extensions/EditorExtensions/MyEditor.cs
@@ -193,7 +193,7 @@ namespace MyBox.EditorTools
 			else if (obj is GameObject go) contextGO = go;
 			else return Array.Empty<Component>();
 			if (contextGO.scene.isLoaded) return contextGO.scene.GetRootGameObjects()
-				.SelectMany(rgo => rgo.GetComponentsInChildren(type));
+				.SelectMany(rgo => rgo.GetComponentsInChildren(type, true));
 			return Array.Empty<Component>();
 		}
 

--- a/Extensions/EditorExtensions/MyEditor.cs
+++ b/Extensions/EditorExtensions/MyEditor.cs
@@ -166,14 +166,17 @@ namespace MyBox.EditorTools
 		/// <summary>
 		/// Get all fields with specified attribute on all Unity Objects
 		/// </summary>
-		public static ObjectField[] GetFieldsWithAttribute<T>(GameObject prefab = null) where T : Attribute
+		public static ObjectField[] GetFieldsWithAttribute<T>(
+			GameObject prefab = null) where T : Attribute
 		{
 			var allObjects = prefab == null ?
 				GetAllUnityObjects() :
 				prefab.GetComponentsInChildren<MonoBehaviour>();
 			return allObjects.Where(obj => obj != null)
 				.SelectMany(obj => obj.GetType()
-					.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+					.GetFields(BindingFlags.Public
+						| BindingFlags.NonPublic
+						| BindingFlags.Instance)
 					.Where(field => field.IsDefined(typeof(T), false))
 					.Select(field => new ObjectField(field, obj)))
 				.ToArray();
@@ -183,8 +186,7 @@ namespace MyBox.EditorTools
 		/// Get all Components in the same scene as a specified GameObject,
 		/// including inactive components.
 		/// </summary>
-		public static IEnumerable<Component> GetAllComponentsInSceneOf(
-			Object obj,
+		public static IEnumerable<Component> GetAllComponentsInSceneOf(Object obj,
 			Type type)
 		{
 			GameObject contextGO = null;

--- a/Extensions/EditorExtensions/MyEditor.cs
+++ b/Extensions/EditorExtensions/MyEditor.cs
@@ -166,7 +166,7 @@ namespace MyBox.EditorTools
 		/// <summary>
 		/// Get all fields with specified attribute on all Unity Objects
 		/// </summary>
-		public static ObjectField[] GetFieldsWithAttribute<T>(
+		public static IEnumerable<ObjectField> GetFieldsWithAttribute<T>(
 			GameObject prefab = null) where T : Attribute
 		{
 			var allObjects = prefab == null ?
@@ -178,8 +178,7 @@ namespace MyBox.EditorTools
 						| BindingFlags.NonPublic
 						| BindingFlags.Instance)
 					.Where(field => field.IsDefined(typeof(T), false))
-					.Select(field => new ObjectField(field, obj)))
-				.ToArray();
+					.Select(field => new ObjectField(field, obj)));
 		}
 
 		/// <summary>

--- a/Extensions/EditorExtensions/MyEditor.cs
+++ b/Extensions/EditorExtensions/MyEditor.cs
@@ -179,6 +179,23 @@ namespace MyBox.EditorTools
 				.ToArray();
 		}
 
+		/// <summary>
+		/// Get all Components in the same scene as a specified GameObject,
+		/// including inactive components.
+		/// </summary>
+		public static IEnumerable<Component> GetAllComponentsInSceneOf(
+			Object obj,
+			Type type)
+		{
+			GameObject contextGO = null;
+			if (obj is Component comp) contextGO = comp.gameObject;
+			else if (obj is GameObject go) contextGO = go;
+			else return Array.Empty<Component>();
+			if (contextGO.scene.isLoaded) return contextGO.scene.GetRootGameObjects()
+				.SelectMany(rgo => rgo.GetComponentsInChildren(type));
+			return Array.Empty<Component>();
+		}
+
 		public struct ObjectField
 		{
 			public readonly FieldInfo Field;


### PR DESCRIPTION
Previously, `MyEditor.ComponentField` struct was used to encapsulate a field and its owning `Component`. But there was little reason for its owner field to be a `Component` other than to make a `GetComponentsInChildren` call in `AutoPropertyAttribute`. This decision inadvertently also has the side effect of `ScriptableObject`s being filtered out entirely in the process of building a list of fields with `AutoProperty` and `MustBeAssigned` attributes, even though `ScriptableObject`s also have their fields displayed on the Inspector.

This PR modified most places that would receive a `MonoBehaviour` to instead receive a `UnityEngine.Object` to receive both `ScriptableObject`s and `MonoBehaviour`s, only (type-safely) casting to `Component` when necessary for `AutoProperty`'s getters. And with that, `AutoProperty` and `MustBeAssigned` will finally work on `ScriptableObject`'s fields.

Out of convenience, I also slipstream an improvement to `AutoProperty`'s Scene mode in this PR to detect inactive components.