### PR TITLE
Fixed weird padding for FoldoutAttribute's box

### DIFF
--- a/Attributes/FoldoutAttribute.cs
+++ b/Attributes/FoldoutAttribute.cs
@@ -270,7 +270,7 @@ namespace MyBox.Internal
             Foldout.onHover.background = uiTex_in_on;
 
             Box = new GUIStyle(GUI.skin.box);
-            Box.padding = new RectOffset(10, 0, 10, 0);
+            Box.padding = new RectOffset(15, 0, 5, 5);
 
             BoxChild = new GUIStyle(GUI.skin.box);
             BoxChild.active.textColor = c_on;


### PR DESCRIPTION
Foldout had weirdly aligned padding (especially visible in dark mode, where the box ended right below the property, without any spacing) that triggered my OCD really hard. Now it's more symmetrical and pleasing to the eye 😉

Also, the issue was in Unity 2020.3.16f1, if that's not occuring in older versions, I guess I could make the new padding dependent on UNITY_2020_2_OR_NEWER being defined.