### PR TITLE
Add some extension methods round 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ TODO Docs - Changed: SceneAttribute is now rendered as popup list of scenes from
 - Extensions: IList.Shuffle() shuffles elements in collection using the Knuth algorithm. Thanks to @tonygiang!
 - Extensions: IList.ExclusiveSample() returns collection of random elements. Thanks to @tonygiang!
 - Extensions: Rigidbody.ToggleConstraints extension. Thanks to @tonygiang!
+- Extensions: Transform.SetLossyScale. Thanks to @tonygiang!
+- Extensions: Camera.WorldPointOffsetByDepth to keep point position on screen but with specified distance from camera. Thanks to @tonygiang!
+- Extensions: Component/GameObject.SetLayerRecursively. Thanks to @tonygiang!
+- Extensions: RectTransform.ShiftAnchor to offset anchor. Thanks to @tonygiang!
+- Extensions: RectTransform.GetAnchorCenter to get mid point between anchorMin and anchorMax. Thanks to @tonygiang!
+- Extensions: RectTransform.GetAnchorDelta to get parent-relative size of the RectTransform. Thanks to @tonygiang!
+- Extensions: Vector.Pow to raise each component of the source Vector to the specified power. Thanks to @tonygiang!
+- Extensions: Vector.ScaleBy immutably returns the result of the source vector multiplied with another vector. Thanks to @tonygiang!
 - Fix: FPSCounter now works correctly if EditorOnly is toggled. Thanks to @TheWalruzz!
 TODO Docs - Fix: DisplayInspector now will show warning if used on property of the wrong type
 TODO Docs - Fix: FoldoutAttribute visual improvements

--- a/Extensions/MyExtensions.cs
+++ b/Extensions/MyExtensions.cs
@@ -36,20 +36,6 @@ namespace MyBox
 				eye);
 		}
 
-		/// <summary>
-		/// Gets a point with the same screen point on the specified Camera as the
-		/// source point, but at the specified distance from said Camera.
-		/// </summary>
-		public static Vector3 SetCameraDepthFrom(this Vector3 worldPos,
-			Camera projectingCamera,
-			float distance,
-			Camera.MonoOrStereoscopicEye eye = Camera.MonoOrStereoscopicEye.Mono)
-		{
-			var screenPoint = projectingCamera.WorldToScreenPoint(worldPos, eye);
-			return projectingCamera.ScreenToWorldPoint(screenPoint.SetZ(distance),
-				eye);
-		}
-
 
 		/// <summary>
 		/// Sets the lossy scale of the source Transform.

--- a/Extensions/MyExtensions.cs
+++ b/Extensions/MyExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
@@ -67,8 +67,11 @@ namespace MyBox
 		/// in the hierarchy.
 		/// </summary>
 		public static T SetLayerRecursively<T>(this T source, string layerName)
-			where T : Component =>
+			where T : Component
+		{
 			source.gameObject.SetLayerRecursively(LayerMask.NameToLayer(layerName));
+			return source;
+		}
 
 		/// <summary>
 		/// Sets a layer to the source's attached GameObject and all of its children

--- a/Extensions/MyExtensions.cs
+++ b/Extensions/MyExtensions.cs
@@ -21,6 +21,80 @@ namespace MyBox
 			var position = camera.WorldToViewportPoint(point);
 			return position.x > 0 && position.y > 0;
 		}
+		
+		/// <summary>
+		/// Gets a point with the same screen point as the source point,
+		/// but at the specified distance from camera.
+		/// </summary>
+		public static Vector3 WorldPointOffsetByDepth(this Camera camera,
+			Vector3 source,
+			float distanceFromCamera,
+			Camera.MonoOrStereoscopicEye eye = Camera.MonoOrStereoscopicEye.Mono)
+		{
+			var screenPoint = camera.WorldToScreenPoint(source, eye);
+			return camera.ScreenToWorldPoint(screenPoint.SetZ(distanceFromCamera),
+				eye);
+		}
+		
+		/// <summary>
+		/// Gets a point with the same screen point on the specified Camera as the
+		/// source point, but at the specified distance from said Camera.
+		/// </summary>
+		public static Vector3 SetCameraDepthFrom(this Vector3 worldPos,
+			Camera projectingCamera,
+			float distance,
+			Camera.MonoOrStereoscopicEye eye = Camera.MonoOrStereoscopicEye.Mono)
+		{
+			var screenPoint = projectingCamera.WorldToScreenPoint(worldPos, eye);
+			return projectingCamera.ScreenToWorldPoint(screenPoint.SetZ(distance),
+				eye);
+		}
+		
+		
+		/// <summary>
+		/// Sets the lossy scale of the source Transform.
+		/// </summary>
+		public static Transform SetLossyScale(this Transform source,
+			Vector3 targetLossyScale)
+		{
+			source.localScale = source.lossyScale.Pow(-1).ScaleBy(targetLossyScale)
+				.ScaleBy(source.localScale);
+			return source;
+		}
+		
+		/// <summary>
+		/// Sets a layer to the source's attached GameObject and all of its children
+		/// in the hierarchy.
+		/// </summary>
+		public static T SetLayerRecursively<T>(this T source, string layer)
+			where T : Component
+		{
+			source.gameObject.SetLayerRecursively(LayerMask.NameToLayer(layer));
+			return source;
+		}
+
+		/// <summary>
+		/// Sets a layer to the source's attached GameObject and all of its children
+		/// in the hierarchy.
+		/// </summary>
+		public static T SetLayerRecursively<T>(this T source, int layer)
+			where T : Component
+		{
+			source.gameObject.SetLayerRecursively(layer);
+			return source;
+		}
+		
+		/// <summary>
+		/// Sets a layer to the source GameObject and all of its children in the
+		/// hierarchy.
+		/// </summary>
+		public static GameObject SetLayerRecursively(this GameObject source,
+			int layer)
+		{
+			var allTransforms = source.GetComponentsInChildren<Transform>(true);
+			foreach (var tf in allTransforms) tf.gameObject.layer = layer;
+			return source;
+		}
 
 
 		public static T GetOrAddComponent<T>(this GameObject gameObject) where T : Component

--- a/Extensions/MyExtensions.cs
+++ b/Extensions/MyExtensions.cs
@@ -21,7 +21,7 @@ namespace MyBox
 			var position = camera.WorldToViewportPoint(point);
 			return position.x > 0 && position.y > 0;
 		}
-		
+
 		/// <summary>
 		/// Gets a point with the same screen point as the source point,
 		/// but at the specified distance from camera.
@@ -35,7 +35,7 @@ namespace MyBox
 			return camera.ScreenToWorldPoint(screenPoint.SetZ(distanceFromCamera),
 				eye);
 		}
-		
+
 		/// <summary>
 		/// Gets a point with the same screen point on the specified Camera as the
 		/// source point, but at the specified distance from said Camera.
@@ -49,8 +49,8 @@ namespace MyBox
 			return projectingCamera.ScreenToWorldPoint(screenPoint.SetZ(distance),
 				eye);
 		}
-		
-		
+
+
 		/// <summary>
 		/// Sets the lossy scale of the source Transform.
 		/// </summary>
@@ -61,17 +61,14 @@ namespace MyBox
 				.ScaleBy(source.localScale);
 			return source;
 		}
-		
+
 		/// <summary>
 		/// Sets a layer to the source's attached GameObject and all of its children
 		/// in the hierarchy.
 		/// </summary>
-		public static T SetLayerRecursively<T>(this T source, string layer)
-			where T : Component
-		{
-			source.gameObject.SetLayerRecursively(LayerMask.NameToLayer(layer));
-			return source;
-		}
+		public static T SetLayerRecursively<T>(this T source, string layerName)
+			where T : Component =>
+			source.gameObject.SetLayerRecursively(LayerMask.NameToLayer(layerName));
 
 		/// <summary>
 		/// Sets a layer to the source's attached GameObject and all of its children
@@ -83,7 +80,18 @@ namespace MyBox
 			source.gameObject.SetLayerRecursively(layer);
 			return source;
 		}
-		
+
+		/// <summary>
+		/// Sets a layer to the source GameObject and all of its children in the
+		/// hierarchy.
+		/// </summary>
+		public static GameObject SetLayerRecursively(this GameObject source,
+			string layerName)
+		{
+			source.SetLayerRecursively(LayerMask.NameToLayer(layerName));
+			return source;
+		}
+
 		/// <summary>
 		/// Sets a layer to the source GameObject and all of its children in the
 		/// hierarchy.
@@ -116,7 +124,7 @@ namespace MyBox
 			return gameObject.GetComponent<T>() != null;
 		}
 
-		
+
 
 		/// <summary>
 		/// Get all components of specified Layer in childs
@@ -127,7 +135,7 @@ namespace MyBox
 			CheckChildsOfLayer(gameObject.transform, layer, list);
 			return list;
 		}
-		
+
 		/// <summary>
 		/// Get all components of specified Layer in childs
 		/// </summary>
@@ -135,7 +143,7 @@ namespace MyBox
 		{
 			return gameObject.GetObjectsOfLayerInChilds(LayerMask.NameToLayer(layer));
 		}
-		
+
 		/// <summary>
 		/// Get all components of specified Layer in childs
 		/// </summary>

--- a/Extensions/MyPhysics.cs
+++ b/Extensions/MyPhysics.cs
@@ -25,5 +25,34 @@ namespace MyBox
 			source.constraints = source.constraints.BitwiseToggle(constraints, state);
 			return source;
 		}
+
+		/// <summary>
+		/// Gets a point with the same screen point on the specified Camera as the
+		/// source point, but at the specified distance from said Camera.
+		/// </summary>
+		public static Vector3 SetCameraDepthFrom(this Vector3 worldPos,
+			Camera projectingCamera,
+			float distance,
+			Camera.MonoOrStereoscopicEye eye = Camera.MonoOrStereoscopicEye.Mono)
+		{
+			var screenPoint = projectingCamera.WorldToScreenPoint(worldPos, eye);
+			return projectingCamera.ScreenToWorldPoint(screenPoint.SetZ(distance),
+				eye);
+		}
+
+		/// <summary>
+		/// Sets the lossy scale of the source Transform.
+		/// </summary>
+		public static Transform SetLossyScale(this Transform source,
+			Vector3 targetLossyScale)
+		{
+			var scaleFactorsToTarget = Vector3.Scale(targetLossyScale,
+				new Vector3(1f / source.lossyScale.x,
+					1f / source.lossyScale.y,
+					1f / source.lossyScale.z));
+			source.localScale = Vector3.Scale(source.localScale,
+				scaleFactorsToTarget);
+			return source;
+		}
 	}
 }

--- a/Extensions/MyPhysics.cs
+++ b/Extensions/MyPhysics.cs
@@ -46,12 +46,8 @@ namespace MyBox
 		public static Transform SetLossyScale(this Transform source,
 			Vector3 targetLossyScale)
 		{
-			var scaleFactorsToTarget = Vector3.Scale(targetLossyScale,
-				new Vector3(1f / source.lossyScale.x,
-					1f / source.lossyScale.y,
-					1f / source.lossyScale.z));
-			source.localScale = Vector3.Scale(source.localScale,
-				scaleFactorsToTarget);
+			source.localScale = source.lossyScale.Pow(-1).ScaleBy(targetLossyScale)
+				.ScaleBy(source.localScale);
 			return source;
 		}
 

--- a/Extensions/MyPhysics.cs
+++ b/Extensions/MyPhysics.cs
@@ -54,5 +54,28 @@ namespace MyBox
 				scaleFactorsToTarget);
 			return source;
 		}
+
+		/// <summary>
+		/// Sets a layer to the source's attached GameObject and all of its children
+		/// in the hierarchy.
+		/// </summary>
+		public static T SetLayerRecursively<T>(this T source, int layer)
+			where T : Component
+		{
+			source.gameObject.SetLayerRecursively(layer);
+			return source;
+		}
+
+		/// <summary>
+		/// Sets a layer to the source GameObject and all of its children in the
+		/// hierarchy.
+		/// </summary>
+		public static GameObject SetLayerRecursively(this GameObject source,
+			int layer)
+		{
+			var allTransforms = source.GetComponentsInChildren<Transform>(true);
+			foreach (var tf in allTransforms) tf.gameObject.layer = layer;
+			return source;
+		}
 	}
 }

--- a/Extensions/MyPhysics.cs
+++ b/Extensions/MyPhysics.cs
@@ -25,53 +25,5 @@ namespace MyBox
 			source.constraints = source.constraints.BitwiseToggle(constraints, state);
 			return source;
 		}
-
-		/// <summary>
-		/// Gets a point with the same screen point on the specified Camera as the
-		/// source point, but at the specified distance from said Camera.
-		/// </summary>
-		public static Vector3 SetCameraDepthFrom(this Vector3 worldPos,
-			Camera projectingCamera,
-			float distance,
-			Camera.MonoOrStereoscopicEye eye = Camera.MonoOrStereoscopicEye.Mono)
-		{
-			var screenPoint = projectingCamera.WorldToScreenPoint(worldPos, eye);
-			return projectingCamera.ScreenToWorldPoint(screenPoint.SetZ(distance),
-				eye);
-		}
-
-		/// <summary>
-		/// Sets the lossy scale of the source Transform.
-		/// </summary>
-		public static Transform SetLossyScale(this Transform source,
-			Vector3 targetLossyScale)
-		{
-			source.localScale = source.lossyScale.Pow(-1).ScaleBy(targetLossyScale)
-				.ScaleBy(source.localScale);
-			return source;
-		}
-
-		/// <summary>
-		/// Sets a layer to the source's attached GameObject and all of its children
-		/// in the hierarchy.
-		/// </summary>
-		public static T SetLayerRecursively<T>(this T source, int layer)
-			where T : Component
-		{
-			source.gameObject.SetLayerRecursively(layer);
-			return source;
-		}
-
-		/// <summary>
-		/// Sets a layer to the source GameObject and all of its children in the
-		/// hierarchy.
-		/// </summary>
-		public static GameObject SetLayerRecursively(this GameObject source,
-			int layer)
-		{
-			var allTransforms = source.GetComponentsInChildren<Transform>(true);
-			foreach (var tf in allTransforms) tf.gameObject.layer = layer;
-			return source;
-		}
 	}
 }

--- a/Extensions/MyUI.cs
+++ b/Extensions/MyUI.cs
@@ -19,9 +19,9 @@ namespace MyBox
 		/// <summary>
 		/// Toggle CanvasGroup Alpha, Interactable and BlocksRaycasts settings
 		/// </summary>
-		public static void SetState(this CanvasGroup _canvas, bool isOn)
+		public static void SetState(this CanvasGroup canvas, bool isOn)
 		{
-			SetCanvasState(_canvas, isOn);
+			SetCanvasState(canvas, isOn);
 		}
 
 

--- a/Extensions/MyUI.cs
+++ b/Extensions/MyUI.cs
@@ -45,5 +45,39 @@ namespace MyBox
 		{
 			trigger.triggers.Add(entry);
 		}
+
+		/// <summary>
+		/// Adds the specified amount to the source RectTransform's both anchors.
+		/// </summary>
+		public static RectTransform ShiftAnchor(this RectTransform source,
+			float x,
+			float y) => source.ShiftAnchor(new Vector2(x, y));
+
+		/// <summary>
+		/// Adds the specified amount as Vector2 to the source RectTransform's both
+		/// anchors.
+		/// </summary>
+		public static RectTransform ShiftAnchor(this RectTransform source,
+			Vector2 delta)
+		{
+			source.anchorMin += delta;
+			source.anchorMax += delta;
+			return source;
+		}
+
+		/// <summary>
+		/// Gets the average of the sum of the source RectTransform's anchors.
+		/// Effectively the parent-relative position of the RectTransform.
+		/// </summary>
+		public static Vector2 GetAnchorCenter(this RectTransform source) =>
+			(source.anchorMin + source.anchorMax) / 2;
+
+		/// <summary>
+		/// Gets the result of the source RectTransform's anchorMax subtracted by its
+		/// anchorMin.
+		/// Effectively the parent-relative size of the RectTransform.
+		/// </summary>
+		public static Vector2 GetAnchorDelta(this RectTransform source) =>
+      source.anchorMax - source.anchorMin;
 	}
 }

--- a/Extensions/MyUI.cs
+++ b/Extensions/MyUI.cs
@@ -78,6 +78,6 @@ namespace MyBox
 		/// Effectively the parent-relative size of the RectTransform.
 		/// </summary>
 		public static Vector2 GetAnchorDelta(this RectTransform source) =>
-      source.anchorMax - source.anchorMin;
+			source.anchorMax - source.anchorMin;
 	}
 }

--- a/Extensions/MyVectors.cs
+++ b/Extensions/MyVectors.cs
@@ -410,7 +410,7 @@ namespace MyBox
 		#endregion
 
 
-		#region Get Closest 
+		#region Get Closest
 
 		/// <summary>
 		/// Finds the position closest to the given one.
@@ -515,6 +515,9 @@ namespace MyBox
 
 		#endregion
 
+
+		#region Pow
+
 		/// <summary>
 		/// Raise each component of the source Vector2 to the specified power.
 		/// </summary>
@@ -539,6 +542,11 @@ namespace MyBox
 				Mathf.Pow(source.z, exponent),
 				Mathf.Pow(source.w, exponent));
 
+		#endregion
+
+
+		#region ScaleBy
+
 		/// <summary>
 		/// Immutably returns the result of the source vector multiplied with
 		/// another vector component-wise.
@@ -559,5 +567,7 @@ namespace MyBox
 		/// </summary>
 		public static Vector4 ScaleBy(this Vector4 source, Vector4 right) =>
 			Vector4.Scale(source, right);
+
+		#endregion
 	}
 }

--- a/Extensions/MyVectors.cs
+++ b/Extensions/MyVectors.cs
@@ -514,5 +514,50 @@ namespace MyBox
 			source.transform.position.To(destination);
 
 		#endregion
+
+		/// <summary>
+		/// Raise each component of the source Vector2 to the specified power.
+		/// </summary>
+		public static Vector2 Pow(this Vector2 source, float exponent) =>
+			new Vector2(Mathf.Pow(source.x, exponent),
+				Mathf.Pow(source.y, exponent));
+
+		/// <summary>
+		/// Raise each component of the source Vector3 to the specified power.
+		/// </summary>
+		public static Vector3 Pow(this Vector3 source, float exponent) =>
+			new Vector3(Mathf.Pow(source.x, exponent),
+				Mathf.Pow(source.y, exponent),
+				Mathf.Pow(source.z, exponent));
+
+		/// <summary>
+		/// Raise each component of the source Vector3 to the specified power.
+		/// </summary>
+		public static Vector4 Pow(this Vector4 source, float exponent) =>
+			new Vector4(Mathf.Pow(source.x, exponent),
+				Mathf.Pow(source.y, exponent),
+				Mathf.Pow(source.z, exponent),
+				Mathf.Pow(source.w, exponent));
+
+		/// <summary>
+		/// Immutably returns the result of the source vector multiplied with
+		/// another vector component-wise.
+		/// </summary>
+		public static Vector2 ScaleBy(this Vector2 source, Vector2 right) =>
+			Vector2.Scale(source, right);
+
+		/// <summary>
+		/// Immutably returns the result of the source vector multiplied with
+		/// another vector component-wise.
+		/// </summary>
+		public static Vector3 ScaleBy(this Vector3 source, Vector3 right) =>
+			Vector3.Scale(source, right);
+
+		/// <summary>
+		/// Immutably returns the result of the source vector multiplied with
+		/// another vector component-wise.
+		/// </summary>
+		public static Vector4 ScaleBy(this Vector4 source, Vector4 right) =>
+			Vector4.Scale(source, right);
 	}
 }


### PR DESCRIPTION
Much of the extension methods in this PR came from my experience scaling UGUI based on anchors (instead of pixels), aka the only way to have "percentage-based" layout in UGUI.

`ShiftAnchor`: This method moves both anchors of the source `RectTransform` by a parent-relative amount, effectively moving the entire transform. For example: `source.ShiftAnchor(0.2f, -0.5f)` will move source 20% to the right and 50% to the bottom. An overload which takes a `Vector2` is also provided.

`GetAnchorCenter`: This returns the midpoint between the source `RectTransform`'s 2 anchors. In anchor-based layout, this is the parent-relative position of the source.

`GetAnchorDelta`: This simply returns `anchorMax - anchorMin`. In anchor-based layout, this is the parent-relative size of the source. You could say it's the `sizeDelta` of a `RectTransform`, but in ratios, not pixels.

`SetCameraDepthFrom`: I use this method to move an object further or closer to a camera while maintaining its position on the viewport of that camera. It simply projects a point to the screen point of a camera, then projects that point back out with the desired depth aka distance from the camera.

`SetLossyScale`: Ever noticed the `lossyScale` property of a `Transform` is read-only? Well, This method will effectively set the `lossyScale` of a `Transform`. With this method, I was able to make two 3D objects that render the same mesh, but are buried under different places in the scene hierarchy to match each other's real size.

`Pow`: Performs an exponent operation on each component of a vector. A helper method for `SetLossyScale` that could be used for other purposes.

`ScaleBy`: There is an undocumented member method `Scale` in each of Unity's vector types that is mutable and returns void. This extension method aims to do what that method does, but immutable and functional style-friendly. A helper method for `SetLossyScale`.

`SetLayerRecursively`: Whenever you change the layer of an object in the scene hierarchy in Unity Editor, you get a popup that asks if you want to apply this layer to all of its children. This extension method does just that, but in runtime. I use this when I need to shift an object and all of the `Renderer` components underneath it to a layer that displays above the UI (and the back underneath the UI).