### PR TITLE
Experimental feature: Custom filter/predicate for AutoProperty

### DIFF
--- a/Attributes/AutoPropertyAttribute.cs
+++ b/Attributes/AutoPropertyAttribute.cs
@@ -19,15 +19,15 @@ namespace MyBox
 	public class AutoPropertyAttribute : PropertyAttribute
 	{
 		public readonly AutoPropertyMode Mode;
-		public Type TargetType = null;
+		public Type PredicateMethodTarget = null;
 		public string PredicateMethodName = null;
 
 		public AutoPropertyAttribute(AutoPropertyMode mode = AutoPropertyMode.Children,
-			Type targetType = null,
+			Type predicateMethodTarget = null,
 			string predicateMethodName = null)
 		{
 			Mode = mode;
-			TargetType = targetType;
+			PredicateMethodTarget = predicateMethodTarget;
 			PredicateMethodName = predicateMethodName;
 		}
 	}
@@ -129,12 +129,12 @@ namespace MyBox.Internal
 				.GetCustomAttributes(typeof(AutoPropertyAttribute), true)
 				.FirstOrDefault() as AutoPropertyAttribute;
 			if (apAttribute == null) return;
-			Func<Object, bool> predicateMethod = (apAttribute.TargetType == null
+			Func<Object, bool> predicateMethod = (apAttribute.PredicateMethodTarget == null
 				|| apAttribute.PredicateMethodName == null) ?
 				_ => true :
 				(Func<Object, bool>)Delegate.CreateDelegate(
 					typeof(Func<Object, bool>),
-					apAttribute.TargetType,
+					apAttribute.PredicateMethodTarget,
 					apAttribute.PredicateMethodName);
 
 			var matchedObjects = ObjectsGetters[apAttribute.Mode]

--- a/Attributes/AutoPropertyAttribute.cs
+++ b/Attributes/AutoPropertyAttribute.cs
@@ -11,7 +11,8 @@ namespace MyBox
 	/// <para></para>
 	/// Advanced usage: Filter found objects with a method. To do that, create a 
 	/// static method or member method of the current class with the same method
-	/// signature as a Func&lt;UnityEngine.Object, bool&gt;.
+	/// signature as a Func&lt;UnityEngine.Object, bool&gt;. Your predicate method
+	/// can be private.
 	/// If your predicate method is a member method of the current class, pass in
 	/// the nameof that method as the second argument.
 	/// If your predicate method is a static method, pass in the typeof class that

--- a/Attributes/AutoPropertyAttribute.cs
+++ b/Attributes/AutoPropertyAttribute.cs
@@ -1,5 +1,6 @@
 using System;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace MyBox
 {
@@ -7,13 +8,28 @@ namespace MyBox
 	/// Automatically assign components to this Property.
 	/// It searches for components from this GO or its children by default.
 	/// Pass in an <c>AutoPropertyMode</c> to override this behaviour.
+	/// <para></para>
+	/// Advanced usage: Filter found objects with a static method. To do
+	/// that, create a static method with the same method signature as a
+	/// Func&lt;UnityEngine.Object, bool&gt;, then pass in the typeof class that
+	/// contains said method as the second argument and the nameof said static
+	/// method as the third argument.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Field)]
 	public class AutoPropertyAttribute : PropertyAttribute
 	{
 		public readonly AutoPropertyMode Mode;
+		public Type TargetType = null;
+		public string PredicateMethodName = null;
 
-		public AutoPropertyAttribute(AutoPropertyMode mode = AutoPropertyMode.Children) => Mode = mode;
+		public AutoPropertyAttribute(AutoPropertyMode mode = AutoPropertyMode.Children,
+			Type targetType = null,
+			string predicateMethodName = null)
+		{
+			Mode = mode;
+			TargetType = targetType;
+			PredicateMethodName = predicateMethodName;
+		}
 	}
 
 	public enum AutoPropertyMode
@@ -48,7 +64,6 @@ namespace MyBox.Internal
 	using UnityEditor;
 	using EditorTools;
 	using UnityEditor.Experimental.SceneManagement;
-	using Object = UnityEngine.Object;
 	using System.Collections.Generic;
 	using System.Linq;
 
@@ -67,40 +82,27 @@ namespace MyBox.Internal
 	[InitializeOnLoad]
 	public static class AutoPropertyHandler
 	{
-		private static readonly Dictionary<AutoPropertyMode, Func<MyEditor.ObjectField, Object[]>> MultipleObjectsGetters
-			= new Dictionary<AutoPropertyMode, Func<MyEditor.ObjectField, Object[]>>
+		private static readonly Dictionary<AutoPropertyMode, Func<MyEditor.ObjectField, Func<Object, bool>, Object[]>> ObjectsGetters
+			= new Dictionary<AutoPropertyMode, Func<MyEditor.ObjectField, Func<Object, bool>, Object[]>>
 			{
-				[AutoPropertyMode.Children] = property => property.Context.As<Component>()
-					?.GetComponentsInChildren(property.Field.FieldType.GetElementType(), true),
-				[AutoPropertyMode.Parent] = property => property.Context.As<Component>()
-					?.GetComponentsInParent(property.Field.FieldType.GetElementType(), true),
-				[AutoPropertyMode.Scene] = property => MyEditor
+				[AutoPropertyMode.Children] = (property, pred) => property.Context
+					.As<Component>()
+					?.GetComponentsInChildren(property.Field.FieldType.GetElementType(), true)
+					.Where(pred).ToArray(),
+				[AutoPropertyMode.Parent] = (property, pred) => property.Context.As<Component>()
+					?.GetComponentsInParent(property.Field.FieldType.GetElementType(), true)
+					.Where(pred).ToArray(),
+				[AutoPropertyMode.Scene] = (property, pred) => MyEditor
 					.GetAllComponentsInSceneOf(property.Context,
-						property.Field.FieldType.GetElementType()).ToArray(),
-				[AutoPropertyMode.Asset] = property => Resources
+						property.Field.FieldType.GetElementType())
+					.Where(pred).ToArray(),
+				[AutoPropertyMode.Asset] = (property, pred) => Resources
 					.FindObjectsOfTypeAll(property.Field.FieldType.GetElementType())
-					.Where(AssetDatabase.Contains).ToArray(),
-				[AutoPropertyMode.Any] = property => Resources
+					.Where(AssetDatabase.Contains)
+					.Where(pred).ToArray(),
+				[AutoPropertyMode.Any] = (property, pred) => Resources
 					.FindObjectsOfTypeAll(property.Field.FieldType.GetElementType())
-			};
-
-		private static readonly Dictionary<AutoPropertyMode, Func<MyEditor.ObjectField, Object>> SingularObjectGetters
-			= new Dictionary<AutoPropertyMode, Func<MyEditor.ObjectField, Object>>
-			{
-				[AutoPropertyMode.Children] = property => property.Context.As<Component>()
-					?.GetComponentInChildren(property.Field.FieldType, true),
-				[AutoPropertyMode.Parent] = property => property.Context.As<Component>()
-					?.GetComponentsInParent(property.Field.FieldType, true)
-					.FirstOrDefault(),
-				[AutoPropertyMode.Scene] = property => MyEditor
-					.GetAllComponentsInSceneOf(property.Context, property.Field.FieldType)
-					.FirstOrDefault(),
-				[AutoPropertyMode.Asset] = property => Resources
-					.FindObjectsOfTypeAll(property.Field.FieldType)
-					.FirstOrDefault(AssetDatabase.Contains),
-				[AutoPropertyMode.Any] = property => Resources
-					.FindObjectsOfTypeAll(property.Field.FieldType)
-					.FirstOrDefault()
+					.Where(pred).ToArray()
 			};
 
 		static AutoPropertyHandler()
@@ -127,22 +129,31 @@ namespace MyBox.Internal
 				.GetCustomAttributes(typeof(AutoPropertyAttribute), true)
 				.FirstOrDefault() as AutoPropertyAttribute;
 			if (apAttribute == null) return;
+			Func<Object, bool> predicateMethod = (apAttribute.TargetType == null
+				|| apAttribute.PredicateMethodName == null) ?
+				_ => true :
+				(Func<Object, bool>)Delegate.CreateDelegate(
+					typeof(Func<Object, bool>),
+					apAttribute.TargetType,
+					apAttribute.PredicateMethodName);
+
+			var matchedObjects = ObjectsGetters[apAttribute.Mode]
+				.Invoke(property, predicateMethod);
 
 			if (property.Field.FieldType.IsArray)
 			{
-				var objects = MultipleObjectsGetters[apAttribute.Mode].Invoke(property);
-				if (objects != null && objects.Length > 0)
+				if (matchedObjects != null && matchedObjects.Length > 0)
 				{
 					var serializedObject = new SerializedObject(property.Context);
 					var serializedProperty = serializedObject.FindProperty(property.Field.Name);
-					serializedProperty.ReplaceArray(objects);
+					serializedProperty.ReplaceArray(matchedObjects);
 					serializedObject.ApplyModifiedProperties();
 					return;
 				}
 			}
 			else
 			{
-				var obj = SingularObjectGetters[apAttribute.Mode].Invoke(property);
+				var obj = matchedObjects.FirstOrDefault();
 				if (obj != null)
 				{
 					var serializedObject = new SerializedObject(property.Context);


### PR DESCRIPTION
This is an implementation of filters/predicate for `AutoProperty`. Sometimes you don't just want to autofill a field by where an object lives, you want to filter out some outliers as well. Let's say you have 100+ prefabs that are all [variants](https://docs.unity3d.com/Manual/PrefabVariants.html) of a base prefab, and you want to autofill only the variant prefabs, not the base prefab.

That's what this new feature is for. The idea is to use reflection to back-bind a static method to a predicate function using the type of the class that holds said static method and the method's name. These 2 pieces of information are passed as the 2nd and 3rd arguments to `AutoPropertyAttribute`'s constructor, respectively.

Please treat this as an extremely experimental feature and don't delay a release for it. A lot of things can go wrong with reflections even though my initial testing yields fine results. Example usage:

```
public class TestScript : MonoBehaviour
{
	[AutoProperty(AutoPropertyMode.Asset,
		nameof(EventPredicate),
		typeof(TestScript))]
	public EventSO[] Events; // There are EventA, EventB, EventC in the project, only EventA and EventC are assigned.

	public static bool EventPredicate(UnityEngine.Object obj) => obj.name != "EventB";
}
```