### PR TITLE
Fix compatibility for Unity 2021.2

### DIFF
--- a/Attributes/AutoPropertyAttribute.cs
+++ b/Attributes/AutoPropertyAttribute.cs
@@ -47,7 +47,11 @@ namespace MyBox.Internal
 {
 	using UnityEditor;
 	using EditorTools;
+#if UNITY_2021_2_OR_NEWER
+	using UnityEditor.SceneManagement;
+#else
 	using UnityEditor.Experimental.SceneManagement;
+#endif
 	using Object = UnityEngine.Object;
 	using System.Collections.Generic;
 	using System.Linq;

--- a/Attributes/MustBeAssignedAttribute.cs
+++ b/Attributes/MustBeAssignedAttribute.cs
@@ -18,7 +18,11 @@ namespace MyBox.Internal
 {
 	using System.Reflection;
 	using UnityEditor;
+#if UNITY_2021_2_OR_NEWER
+	using UnityEditor.SceneManagement;
+#else
 	using UnityEditor.Experimental.SceneManagement;
+#endif
 	using EditorTools;
 
 	[InitializeOnLoad]


### PR DESCRIPTION
From Unity 2021.2, namespace UnityEditor.Experimental.SceneManagement is replaced with UnityEditor.SceneManagement.
API Updater would fix namespace but it may not work on batch mode in some conditions.