### PR TITLE
Remove dependencies to Unity Physics and AI Modules and cover them by defines

### DIFF
--- a/Extensions/EditorExtensions/MyHandles.cs
+++ b/Extensions/EditorExtensions/MyHandles.cs
@@ -41,7 +41,8 @@ namespace MyBox.EditorTools
 			Handles.DrawLine(position, position + left * headLength);
 		}
 
-
+#if UNITY_AI_ENABLED
+        
 		/// <summary>
 		/// Draw arrowed gizmo in scene view to visualize path
 		/// </summary>
@@ -56,6 +57,8 @@ namespace MyBox.EditorTools
 				DrawDirectionalLine(cornerA, cornerB, size, size);
 			}
 		}
+        
+#endif
 
 		/// <summary>
 		/// Draw flying path of height prom pointA to pointB

--- a/Extensions/MyAlgorithms.cs
+++ b/Extensions/MyAlgorithms.cs
@@ -131,6 +131,8 @@ namespace MyBox
 			return source;
 		}
 
+#if UNITY_PHYSICS_ENABLED
+        
 		/// <summary>
 		/// Sets the state of the source enum, chosen by the 1-bits in the specified
 		/// bit mask.
@@ -143,7 +145,11 @@ namespace MyBox
 			if (state) return source | bitMask;
 			else return source & ~bitMask;
 		}
-
+        
+#endif
+        
+#if UNITY_PHYSICS2D_ENABLED
+        
 		/// <summary>
 		/// Sets the state of the source enum, chosen by the 1-bits in the specified
 		/// bit mask.
@@ -156,5 +162,7 @@ namespace MyBox
 			if (state) return source | bitMask;
 			else return source & ~bitMask;
 		}
+        
+#endif
 	}
 }

--- a/Extensions/MyExtensions.cs
+++ b/Extensions/MyExtensions.cs
@@ -160,6 +160,7 @@ namespace MyBox
 			}
 		}
 
+#if UNITY_PHYSICS_ENABLED
 
 		/// <summary>
 		/// Swap Rigidbody IsKinematic and DetectCollisions
@@ -172,6 +173,7 @@ namespace MyBox
 			body.detectCollisions = state;
 		}
 
+#endif
 
 		/// <summary>
 		/// Find all Components of specified interface
@@ -216,6 +218,8 @@ namespace MyBox
 			if (components == null || components.Length == 0) return null;
 			return components.GroupBy(h => h.transform.GetInstanceID()).Select(g => g.First()).ToArray();
 		}
+        
+#if UNITY_PHYSICS2D_ENABLED
 
 		/// <summary>
 		/// Get hits with unique owner Instance ID
@@ -226,7 +230,7 @@ namespace MyBox
 			return hits.GroupBy(h => h.transform.GetInstanceID()).Select(g => g.First()).ToArray();
 		}
 
-		/// <summary>
+        /// <summary>
 		/// Get colliders with unique owner Instance ID
 		/// </summary>
 		public static Collider2D[] OneHitPerInstance(this Collider2D[] hits)
@@ -243,6 +247,8 @@ namespace MyBox
 			if (hits == null || hits.Length == 0) return null;
 			return hits.GroupBy(h => h.transform.GetInstanceID()).Select(g => g.First()).ToList();
 		}
+        
+#endif
 
 		#endregion
 	}

--- a/Extensions/MyNavMesh.cs
+++ b/Extensions/MyNavMesh.cs
@@ -4,6 +4,8 @@ using UnityEngine.AI;
 
 namespace MyBox
 {
+#if UNITY_AI_ENABLED
+    
 	public static class MyNavMesh
 	{
 		/// <summary>
@@ -90,4 +92,6 @@ namespace MyBox
 			}
 		}
 	}
+    
+#endif
 }

--- a/Extensions/MyPhysics.cs
+++ b/Extensions/MyPhysics.cs
@@ -4,6 +4,8 @@ namespace MyBox
 {
 	public static class MyPhysics
 	{
+#if UNITY_PHYSICS_ENABLED
+        
 		/// <summary>
 		/// Sets the state of constraints for the source Rigidbody.
 		/// </summary>
@@ -14,7 +16,11 @@ namespace MyBox
 			source.constraints = source.constraints.BitwiseToggle(constraints, state);
 			return source;
 		}
+        
+#endif
 
+#if UNITY_PHYSICS2D_ENABLED
+        
 		/// <summary>
 		/// Sets the state of constraints for the source Rigidbody2D.
 		/// </summary>
@@ -25,5 +31,7 @@ namespace MyBox
 			source.constraints = source.constraints.BitwiseToggle(constraints, state);
 			return source;
 		}
+        
+#endif
 	}
 }

--- a/MyBox.asmdef
+++ b/MyBox.asmdef
@@ -8,5 +8,22 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": []
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.ai",
+            "expression": "",
+            "define": "UNITY_AI_ENABLED"
+        },
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "",
+            "define": "UNITY_PHYSICS2D_ENABLED"
+        },
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "",
+            "define": "UNITY_PHYSICS_ENABLED"
+        }
+    ],
+    "noEngineReferences": false
 }

--- a/Types/ColliderGizmo.cs
+++ b/Types/ColliderGizmo.cs
@@ -43,7 +43,7 @@ namespace MyBox
 		private List<BoxCollider2D> _boxColliders2D;
 		private List<CircleCollider2D> _circleColliders2D;
 #endif
-        
+
 #if UNITY_PHYSICS_ENABLED
 		private List<BoxCollider> _boxColliders;
 		private List<SphereCollider> _sphereColliders;
@@ -80,13 +80,13 @@ namespace MyBox
 			_withColliders.Clear();
 
 #if UNITY_AI_ENABLED
-            _navMeshObstacle = gameObject.GetComponent<NavMeshObstacle>();
+			_navMeshObstacle = gameObject.GetComponent<NavMeshObstacle>();
 #endif
-            
+
 #if UNITY_PHYSICS2D_ENABLED
-            if (_edgeColliders2D != null) _edgeColliders2D.Clear();
-            if (_boxColliders2D != null) _boxColliders2D.Clear();
-            if (_circleColliders2D != null) _circleColliders2D.Clear();
+			if (_edgeColliders2D != null) _edgeColliders2D.Clear();
+			if (_boxColliders2D != null) _boxColliders2D.Clear();
+			if (_circleColliders2D != null) _circleColliders2D.Clear();
 
 			Collider2D[] colliders2d = IncludeChildColliders ? gameObject.GetComponentsInChildren<Collider2D>() : gameObject.GetComponents<Collider2D>();
 
@@ -121,14 +121,14 @@ namespace MyBox
 				}
 			}
 #endif
-            
+
 #if UNITY_PHYSICS_ENABLED
-            if (_boxColliders != null) _boxColliders.Clear();
-            if (_sphereColliders != null) _sphereColliders.Clear();
-            if (_meshColliders != null) _meshColliders.Clear();
-            
-            Collider[] colliders = IncludeChildColliders ? gameObject.GetComponentsInChildren<Collider>() : gameObject.GetComponents<Collider>();
-            
+			if (_boxColliders != null) _boxColliders.Clear();
+			if (_sphereColliders != null) _sphereColliders.Clear();
+			if (_meshColliders != null) _meshColliders.Clear();
+
+			Collider[] colliders = IncludeChildColliders ? gameObject.GetComponentsInChildren<Collider>() : gameObject.GetComponents<Collider>();
+
 			for (var i = 0; i < colliders.Length; i++)
 			{
 				var c = colliders[i];
@@ -167,7 +167,7 @@ namespace MyBox
 		#region Drawers
 
 #if UNITY_PHYSICS2D_ENABLED
-        
+
 		private void DrawEdgeCollider2D(EdgeCollider2D coll)
 		{
 			var target = coll.transform;
@@ -204,7 +204,7 @@ namespace MyBox
 			Gizmos.matrix = Matrix4x4.identity;
 		}
 
-        private void DrawCircleCollider2D(CircleCollider2D coll)
+		private void DrawCircleCollider2D(CircleCollider2D coll)
 		{
 			var target = coll.transform;
 			var offset = coll.offset;
@@ -213,18 +213,18 @@ namespace MyBox
 		}
 
 #endif
-        
+
 #if UNITY_PHYSICS_ENABLED
 
-        private void DrawBoxCollider(BoxCollider coll)
-        {
-            var target = coll.transform;
-            Gizmos.matrix = Matrix4x4.TRS(target.position, target.rotation, target.lossyScale);
-            DrawColliderGizmo(coll.center, coll.size);
-            Gizmos.matrix = Matrix4x4.identity;
-        }
+		private void DrawBoxCollider(BoxCollider coll)
+		{
+			var target = coll.transform;
+			Gizmos.matrix = Matrix4x4.TRS(target.position, target.rotation, target.lossyScale);
+			DrawColliderGizmo(coll.center, coll.size);
+			Gizmos.matrix = Matrix4x4.identity;
+		}
 
-        private void DrawSphereCollider(SphereCollider coll)
+		private void DrawSphereCollider(SphereCollider coll)
 		{
 			var target = coll.transform;
 			var scale = target.lossyScale;
@@ -236,19 +236,20 @@ namespace MyBox
 		private void DrawMeshCollider(MeshCollider coll)
 		{
 			var target = coll.transform;
-			
+
 			if (DrawWire)
 			{
 				Gizmos.color = _wireGizmoColor;
 				Gizmos.DrawWireMesh(coll.sharedMesh, target.position, target.rotation, target.localScale * 1.01f);
 			}
+
 			if (DrawFill)
 			{
 				Gizmos.color = _fillGizmoColor;
 				Gizmos.DrawMesh(coll.sharedMesh, target.position, target.rotation, target.localScale * 1.01f);
 			}
 		}
-        
+
 #endif
 
 #if UNITY_AI_ENABLED
@@ -256,7 +257,7 @@ namespace MyBox
 		private void DrawNavMeshObstacle(NavMeshObstacle obstacle)
 		{
 			var target = obstacle.transform;
-			
+
 			if (obstacle.shape == NavMeshObstacleShape.Box)
 			{
 				Gizmos.matrix = Matrix4x4.TRS(target.position, target.rotation, target.lossyScale);
@@ -271,7 +272,7 @@ namespace MyBox
 				DrawColliderGizmo(target.position + new Vector3(center.x, center.y, 0.0f), obstacle.radius * max);
 			}
 		}
-        
+
 #endif
 
 
@@ -291,7 +292,7 @@ namespace MyBox
 #if UNITY_AI_ENABLED
 			if (_navMeshObstacle != null) DrawNavMeshObstacle(_navMeshObstacle);
 #endif
-            
+
 #if UNITY_PHYSICS2D_ENABLED
 			if (_edgeColliders2D != null)
 			{
@@ -320,7 +321,7 @@ namespace MyBox
 				}
 			}
 #endif
-            
+
 #if UNITY_PHYSICS_ENABLED
 			if (_boxColliders != null)
 			{
@@ -339,7 +340,7 @@ namespace MyBox
 					DrawSphereCollider(sphere);
 				}
 			}
-			
+
 			if (_meshColliders != null)
 			{
 				foreach (var mesh in _meshColliders)
@@ -481,147 +482,147 @@ namespace MyBox
 
 #if UNITY_EDITOR
 
-	namespace MyBox.Internal
+namespace MyBox.Internal
+{
+	[CustomEditor(typeof(ColliderGizmo)), CanEditMultipleObjects]
+	public class ColliderGizmoEditor : Editor
 	{
-		[CustomEditor(typeof(ColliderGizmo)), CanEditMultipleObjects]
-		public class ColliderGizmoEditor : Editor
+		private SerializedProperty _enabledProperty;
+		private SerializedProperty _alphaProperty;
+		private SerializedProperty _drawWireProperty;
+		private SerializedProperty _wireColorProperty;
+		private SerializedProperty _drawFillProperty;
+		private SerializedProperty _fillColorProperty;
+		private SerializedProperty _drawCenterProperty;
+		private SerializedProperty _centerColorProperty;
+		private SerializedProperty _centerRadiusProperty;
+
+		private SerializedProperty _includeChilds;
+
+		private ColliderGizmo _target;
+
+		private int _collidersCount;
+
+		private void OnEnable()
 		{
-			private SerializedProperty _enabledProperty;
-			private SerializedProperty _alphaProperty;
-			private SerializedProperty _drawWireProperty;
-			private SerializedProperty _wireColorProperty;
-			private SerializedProperty _drawFillProperty;
-			private SerializedProperty _fillColorProperty;
-			private SerializedProperty _drawCenterProperty;
-			private SerializedProperty _centerColorProperty;
-			private SerializedProperty _centerRadiusProperty;
+			_target = target as ColliderGizmo;
 
-			private SerializedProperty _includeChilds;
+			_enabledProperty = serializedObject.FindProperty("m_Enabled");
+			_alphaProperty = serializedObject.FindProperty("Alpha");
 
-			private ColliderGizmo _target;
+			_drawWireProperty = serializedObject.FindProperty("DrawWire");
+			_wireColorProperty = serializedObject.FindProperty("WireColor");
 
-			private int _collidersCount;
+			_drawFillProperty = serializedObject.FindProperty("DrawFill");
+			_fillColorProperty = serializedObject.FindProperty("FillColor");
 
-			private void OnEnable()
+			_drawCenterProperty = serializedObject.FindProperty("DrawCenter");
+			_centerColorProperty = serializedObject.FindProperty("CenterColor");
+			_centerRadiusProperty = serializedObject.FindProperty("CenterMarkerRadius");
+
+			_includeChilds = serializedObject.FindProperty("IncludeChildColliders");
+
+			_collidersCount = CollidersCount();
+		}
+
+
+		public override void OnInspectorGUI()
+		{
+			Undo.RecordObject(_target, "CG_State");
+
+			EditorGUILayout.PropertyField(_enabledProperty);
+
+			EditorGUI.BeginChangeCheck();
+			_target.Preset = (ColliderGizmo.Presets)EditorGUILayout.EnumPopup("Color Preset", _target.Preset);
+			if (EditorGUI.EndChangeCheck())
 			{
-				_target = target as ColliderGizmo;
-
-				_enabledProperty = serializedObject.FindProperty("m_Enabled");
-				_alphaProperty = serializedObject.FindProperty("Alpha");
-
-				_drawWireProperty = serializedObject.FindProperty("DrawWire");
-				_wireColorProperty = serializedObject.FindProperty("WireColor");
-
-				_drawFillProperty = serializedObject.FindProperty("DrawFill");
-				_fillColorProperty = serializedObject.FindProperty("FillColor");
-
-				_drawCenterProperty = serializedObject.FindProperty("DrawCenter");
-				_centerColorProperty = serializedObject.FindProperty("CenterColor");
-				_centerRadiusProperty = serializedObject.FindProperty("CenterMarkerRadius");
-
-				_includeChilds = serializedObject.FindProperty("IncludeChildColliders");
-
-				_collidersCount = CollidersCount();
-			}
-
-
-			public override void OnInspectorGUI()
-			{
-				Undo.RecordObject(_target, "CG_State");
-
-				EditorGUILayout.PropertyField(_enabledProperty);
-
-				EditorGUI.BeginChangeCheck();
-				_target.Preset = (ColliderGizmo.Presets) EditorGUILayout.EnumPopup("Color Preset", _target.Preset);
-				if (EditorGUI.EndChangeCheck())
+				foreach (var singleTarget in targets)
 				{
-					foreach (var singleTarget in targets)
-					{
-						var gizmo = (ColliderGizmo) singleTarget;
-						gizmo.ChangePreset(_target.Preset);
-						EditorUtility.SetDirty(gizmo);
-					}
-				}
-
-				_alphaProperty.floatValue = EditorGUILayout.Slider("Overall Transparency", _alphaProperty.floatValue, 0, 1);
-
-
-				EditorGUI.BeginChangeCheck();
-				using (new EditorGUILayout.HorizontalScope())
-				{
-					EditorGUILayout.PropertyField(_drawWireProperty);
-					if (_drawWireProperty.boolValue) EditorGUILayout.PropertyField(_wireColorProperty, new GUIContent(""));
-				}
-
-				using (new EditorGUILayout.HorizontalScope())
-				{
-					EditorGUILayout.PropertyField(_drawFillProperty);
-					if (_drawFillProperty.boolValue) EditorGUILayout.PropertyField(_fillColorProperty, new GUIContent(""));
-				}
-
-				using (new EditorGUILayout.HorizontalScope())
-				{
-					EditorGUILayout.PropertyField(_drawCenterProperty);
-					if (_drawCenterProperty.boolValue)
-					{
-						EditorGUILayout.PropertyField(_centerColorProperty, GUIContent.none);
-						EditorGUILayout.PropertyField(_centerRadiusProperty);
-					}
-				}
-
-
-				if (EditorGUI.EndChangeCheck())
-				{
-					var presetProp = serializedObject.FindProperty("Preset");
-					var customWireColor = serializedObject.FindProperty("CustomWireColor");
-					var customFillColor = serializedObject.FindProperty("CustomFillColor");
-					var customCenterColor = serializedObject.FindProperty("CustomCenterColor");
-
-					presetProp.enumValueIndex = (int) ColliderGizmo.Presets.Custom;
-					customWireColor.colorValue = _wireColorProperty.colorValue;
-					customFillColor.colorValue = _fillColorProperty.colorValue;
-					customCenterColor.colorValue = _centerColorProperty.colorValue;
-				}
-
-				EditorGUILayout.PropertyField(_includeChilds);
-
-				int collidersCountCheck = CollidersCount();
-				bool collidersCountChanged = collidersCountCheck != _collidersCount;
-				_collidersCount = collidersCountCheck;
-
-				if (GUI.changed || collidersCountChanged)
-				{
-					serializedObject.ApplyModifiedProperties();
-					EditorUtility.SetDirty(_target);
-
-					_target.Refresh();
+					var gizmo = (ColliderGizmo)singleTarget;
+					gizmo.ChangePreset(_target.Preset);
+					EditorUtility.SetDirty(gizmo);
 				}
 			}
 
-			private int CollidersCount()
+			_alphaProperty.floatValue = EditorGUILayout.Slider("Overall Transparency", _alphaProperty.floatValue, 0, 1);
+
+
+			EditorGUI.BeginChangeCheck();
+			using (new EditorGUILayout.HorizontalScope())
 			{
-                int result = 0;
-                
-				if (_includeChilds.boolValue)
-                {
-#if UNITY_PHYSICS_ENABLED
-                    result += _target.gameObject.GetComponentsInChildren<Collider>().Length;
-#endif
-#if UNITY_PHYSICS2D_ENABLED
-                    result += _target.gameObject.GetComponentsInChildren<Collider2D>().Length;
-#endif
-					return result;
+				EditorGUILayout.PropertyField(_drawWireProperty);
+				if (_drawWireProperty.boolValue) EditorGUILayout.PropertyField(_wireColorProperty, new GUIContent(""));
+			}
+
+			using (new EditorGUILayout.HorizontalScope())
+			{
+				EditorGUILayout.PropertyField(_drawFillProperty);
+				if (_drawFillProperty.boolValue) EditorGUILayout.PropertyField(_fillColorProperty, new GUIContent(""));
+			}
+
+			using (new EditorGUILayout.HorizontalScope())
+			{
+				EditorGUILayout.PropertyField(_drawCenterProperty);
+				if (_drawCenterProperty.boolValue)
+				{
+					EditorGUILayout.PropertyField(_centerColorProperty, GUIContent.none);
+					EditorGUILayout.PropertyField(_centerRadiusProperty);
 				}
-                
-#if UNITY_PHYSICS_ENABLED
-                result += _target.gameObject.GetComponents<Collider>().Length;
-#endif
-#if UNITY_PHYSICS2D_ENABLED
-                    result += _target.gameObject.GetComponents<Collider2D>().Length;
-#endif
-                return result;
+			}
+
+
+			if (EditorGUI.EndChangeCheck())
+			{
+				var presetProp = serializedObject.FindProperty("Preset");
+				var customWireColor = serializedObject.FindProperty("CustomWireColor");
+				var customFillColor = serializedObject.FindProperty("CustomFillColor");
+				var customCenterColor = serializedObject.FindProperty("CustomCenterColor");
+
+				presetProp.enumValueIndex = (int)ColliderGizmo.Presets.Custom;
+				customWireColor.colorValue = _wireColorProperty.colorValue;
+				customFillColor.colorValue = _fillColorProperty.colorValue;
+				customCenterColor.colorValue = _centerColorProperty.colorValue;
+			}
+
+			EditorGUILayout.PropertyField(_includeChilds);
+
+			int collidersCountCheck = CollidersCount();
+			bool collidersCountChanged = collidersCountCheck != _collidersCount;
+			_collidersCount = collidersCountCheck;
+
+			if (GUI.changed || collidersCountChanged)
+			{
+				serializedObject.ApplyModifiedProperties();
+				EditorUtility.SetDirty(_target);
+
+				_target.Refresh();
 			}
 		}
+
+		private int CollidersCount()
+		{
+			int result = 0;
+
+			if (_includeChilds.boolValue)
+			{
+#if UNITY_PHYSICS_ENABLED
+				result += _target.gameObject.GetComponentsInChildren<Collider>().Length;
+#endif
+#if UNITY_PHYSICS2D_ENABLED
+				result += _target.gameObject.GetComponentsInChildren<Collider2D>().Length;
+#endif
+				return result;
+			}
+
+#if UNITY_PHYSICS_ENABLED
+			result += _target.gameObject.GetComponents<Collider>().Length;
+#endif
+#if UNITY_PHYSICS2D_ENABLED
+			result += _target.gameObject.GetComponents<Collider2D>().Length;
+#endif
+			return result;
+		}
 	}
+}
 
 #endif

--- a/Types/ColliderToMesh.cs
+++ b/Types/ColliderToMesh.cs
@@ -3,6 +3,8 @@ using UnityEngine;
 
 namespace MyBox
 {
+#if UNITY_PHYSICS2D_ENABLED
+    
 	[RequireComponent(typeof(PolygonCollider2D))]
 	[RequireComponent(typeof(MeshFilter))]
 	[RequireComponent(typeof(MeshRenderer))]
@@ -174,4 +176,6 @@ namespace MyBox
 
 		#endregion
 	}
+    
+#endif
 }

--- a/Types/EditorTypes/SceneClickHandler.cs
+++ b/Types/EditorTypes/SceneClickHandler.cs
@@ -1,4 +1,5 @@
 ﻿#if UNITY_EDITOR
+#if UNITY_PHYSICS_ENABLED
 using System;
 using UnityEngine;
 using UnityEditor;
@@ -51,7 +52,7 @@ namespace MyBox.EditorTools
 		private void FocusSceneView()
 		{
 			if (SceneView.sceneViews.Count == 0) return;
-			((SceneView) SceneView.sceneViews[0]).Focus();
+			((SceneView)SceneView.sceneViews[0]).Focus();
 		}
 
 		/// <summary>
@@ -79,19 +80,14 @@ namespace MyBox.EditorTools
 		private readonly Action<Vector3> _onClick;
 
 		private bool _enabled;
-        
-#pragma warning disable 414
-        private bool _useMask;
-        private LayerMask _mask;
-#pragma warning restore 414
-        
+		private bool _useMask;
+		private LayerMask _mask;
 
 
 		private void OnSceneGUI(SceneView sceneview)
 		{
 			if (!Enabled) return;
-            
-#if UNITY_PHYSICS_ENABLED
+
 			var ray = HandleUtility.GUIPointToWorldRay(Event.current.mousePosition);
 			RaycastHit hit;
 			if (_useMask ? Physics.Raycast(ray, out hit, _mask.value) : Physics.Raycast(ray, out hit))
@@ -104,7 +100,6 @@ namespace MyBox.EditorTools
 				if (Handles.Button(Vector3.zero, SceneView.currentDrawingSceneView.rotation, 30, 5000, Handles.RectangleHandleCap))
 					HandleClick(hit.point);
 			}
-#endif
 
 			if (Event.current.type == EventType.KeyDown && Event.current.keyCode == KeyCode.Escape) HandleEscape();
 		}
@@ -128,4 +123,5 @@ namespace MyBox.EditorTools
 		}
 	}
 }
+#endif
 #endif

--- a/Types/EditorTypes/SceneClickHandler.cs
+++ b/Types/EditorTypes/SceneClickHandler.cs
@@ -79,14 +79,19 @@ namespace MyBox.EditorTools
 		private readonly Action<Vector3> _onClick;
 
 		private bool _enabled;
-		private bool _useMask;
-		private LayerMask _mask;
+        
+#pragma warning disable 414
+        private bool _useMask;
+        private LayerMask _mask;
+#pragma warning restore 414
+        
 
 
 		private void OnSceneGUI(SceneView sceneview)
 		{
 			if (!Enabled) return;
-
+            
+#if UNITY_PHYSICS_ENABLED
 			var ray = HandleUtility.GUIPointToWorldRay(Event.current.mousePosition);
 			RaycastHit hit;
 			if (_useMask ? Physics.Raycast(ray, out hit, _mask.value) : Physics.Raycast(ray, out hit))
@@ -99,6 +104,7 @@ namespace MyBox.EditorTools
 				if (Handles.Button(Vector3.zero, SceneView.currentDrawingSceneView.rotation, 30, 5000, Handles.RectangleHandleCap))
 					HandleClick(hit.point);
 			}
+#endif
 
 			if (Event.current.type == EventType.KeyDown && Event.current.keyCode == KeyCode.Escape) HandleEscape();
 		}

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
 "unity": "2018.3",
 "dependencies": {
     "com.unity.ugui": "1.0.0",
-    "com.unity.modules.ai": "1.0.0",
-    "com.unity.modules.physics2d": "1.0.0"
+    "com.unity.modules.imageconversion": "1.0.0"
 },
 "documentationUrl": "https://github.com/Deadcows/MyBox/wiki",
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
 
 "unity": "2018.3",
 "dependencies": {
-    "com.unity.ugui": "1.0.0",
-    "com.unity.modules.imageconversion": "1.0.0"
+    "com.unity.ugui": "1.0.0"
 },
 "documentationUrl": "https://github.com/Deadcows/MyBox/wiki",
 


### PR DESCRIPTION
I just started new project, where I don't need physics at all. But MyBox has hard dependency on this modules. So I broke that coupling by using asmdef Version Defines feature.