### PR TITLE
Fix ReadOnlyAttribute conditional feature

### DIFF
--- a/Attributes/ReadOnlyAttribute.cs
+++ b/Attributes/ReadOnlyAttribute.cs
@@ -15,9 +15,8 @@ namespace MyBox
         { }
 
         public ReadOnlyAttribute(params string[] fieldToCheck) : base(fieldToCheck)
-        {
-
-        }
+        { }
+        
         public ReadOnlyAttribute(bool useMethod, string method, bool inverse = false) : base(useMethod, method, inverse)
         { }
     }

--- a/Attributes/ReadOnlyAttribute.cs
+++ b/Attributes/ReadOnlyAttribute.cs
@@ -4,6 +4,22 @@ namespace MyBox
 {
     public class ReadOnlyAttribute : ConditionalFieldAttribute
     {
+        /// <param name="fieldToCheck">String name of field to check value</param>
+        /// <param name="inverse">Inverse check result</param>
+        /// <param name="compareValues">On which values field will be shown in inspector</param>
+        public ReadOnlyAttribute(string fieldToCheck, bool inverse = false, params object[] compareValues) : base(fieldToCheck, inverse, compareValues)
+        { }
+
+
+        public ReadOnlyAttribute(string[] fieldToCheck, bool[] inverse = null, params object[] compare) : base(fieldToCheck, inverse, compare)
+        { }
+
+        public ReadOnlyAttribute(params string[] fieldToCheck) : base(fieldToCheck)
+        {
+
+        }
+        public ReadOnlyAttribute(bool useMethod, string method, bool inverse = false) : base(useMethod, method, inverse)
+        { }
     }
 }
 


### PR DESCRIPTION
Constructors aren't inherited, so the conditional features of this attribute couldn't be used (no constructor takes >0 arguments)