### PR TITLE
Improve compatibility with Unity 2019

### DIFF
--- a/Attributes/DisplayInspectorAttribute.cs
+++ b/Attributes/DisplayInspectorAttribute.cs
@@ -134,9 +134,12 @@ namespace MyBox.Internal
 
 		private bool IsFolded(SerializedProperty property)
 		{
-			_foldout ??= new EditorPrefsBool("DisplayInspectorFoldout" +
+			if(_foldout == null)
+			{
+				_foldout = new EditorPrefsBool("DisplayInspectorFoldout" +
 			                                 property.GetParent().GetType().Name +
 			                                 property.propertyPath);
+			}
 			return _foldout.Value;
 		}
 		


### PR DESCRIPTION
In the last update (1.7.0) the DisplayInspectorAttribute.cs script uses <b>Null Coalescing Assignment</b>, this causes an incompatibility with old versions of unity since this is a feature of c# 8.0 onwards. It has been changed to a compatible code to be able to use the latest update.

More info about Null Coalescing Assignment: https://learn.microsoft.com/dotnet/csharp/language-reference/proposals/csharp-8.0/null-coalescing-assignment