### PR TITLE
Change Billboard.cs to use Camera.main instead of FindObjectOfType<Camera>()

### DIFF
--- a/Types/Billboard.cs
+++ b/Types/Billboard.cs
@@ -11,7 +11,6 @@ namespace MyBox
 			_camera = null;
 		}
 
-
 		public Transform FacedObject;
 
 		private Transform ActiveFacedObject

--- a/Types/Billboard.cs
+++ b/Types/Billboard.cs
@@ -1,10 +1,17 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace MyBox
 {
 	[ExecuteAlways]
 	public class Billboard : MonoBehaviour
 	{
+		[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+		private static void Initialize()
+		{
+			_camera = null;
+		}
+
+
 		public Transform FacedObject;
 
 		private Transform ActiveFacedObject
@@ -13,7 +20,7 @@ namespace MyBox
 			{
 				if (FacedObject != null) return FacedObject;
 				if (_camera != null) return _camera.transform;
-				_camera = FindObjectOfType<Camera>();
+				_camera = Camera.main;
 				
 				return _camera == null ? null : _camera.transform;
 			}
@@ -27,4 +34,3 @@ namespace MyBox
 		}
 	}
 }
-


### PR DESCRIPTION
If your scene has multiple cameras, then FindObjectOfType is not deterministic. Camera.main will reliably get the main camera.

I also added a RuntimeInitializeOnLoadMethod method for compatibility with EnterPlayMode settings.