### PR TITLE
Fix not accessing attributes of parent class type 

### DIFF
--- a/Extensions/EditorExtensions/MyEditor.cs
+++ b/Extensions/EditorExtensions/MyEditor.cs
@@ -205,11 +205,22 @@ namespace MyBox.EditorTools
 			foreach (var o in objects)
 			{
 				if (o == null) continue;
-				var fields = o.GetType().GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-				foreach (var field in fields)
+				var objectType = o.GetType();
+				
+				while (objectType != null)
 				{
-					if (!field.IsDefined(desiredAttribute, false)) continue;
-					result.Add(new ObjectField(field, o));
+					var fields = objectType.GetFields(
+						BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance
+					);
+					
+					foreach (var field in fields)
+					{
+						if (!field.IsDefined(desiredAttribute, false)) continue;
+
+						result.Add(new ObjectField(field, o));
+					}
+
+					objectType = objectType.BaseType;
 				}
 			}
 


### PR DESCRIPTION
Sometimes AutoProperty can be used in parent class of object and then it would be completely ignored withput that fix