### PR TITLE
Fixed generic custom property drawers not working with MyBox attributes.

### DIFF
--- a/Tools/Internal/CustomDrawerUtility.cs
+++ b/Tools/Internal/CustomDrawerUtility.cs
@@ -1,4 +1,4 @@
-﻿#if UNITY_EDITOR
+﻿// #if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -75,9 +75,14 @@ namespace MyBox.Internal
 			// Of all property drawers in the assembly we need to find one that affects target type
 			// or one of the base types of target type
 			var checkType = drawerTarget;
+			if (checkType.IsGenericType)
+			{
+				checkType = checkType.GetGenericTypeDefinition();
+			}
+
 			while (checkType != null)
 			{
-				if (PropertyDrawersInAssembly.TryGetValue(drawerTarget, out var drawer)) return drawer;
+				if (PropertyDrawersInAssembly.TryGetValue(checkType, out var drawer)) return drawer;
 				checkType = checkType.BaseType;
 			}
 

--- a/Tools/Internal/CustomDrawerUtility.cs
+++ b/Tools/Internal/CustomDrawerUtility.cs
@@ -1,4 +1,4 @@
-﻿// #if UNITY_EDITOR
+﻿#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.Linq;


### PR DESCRIPTION
When using a generic custom property drawer (e.g. `[CustomPropertyDrawer(typeof(TestGenericType<>), true)]`), if a MyBox attribute is attached to a member field of type that uses said custom generic drawer, it will not use the custom drawer, but will instead just use the default inspector drawer for that field. After further inspection, I found that this was because the generic drawer types were not being found during drawer dictionary lookup.

I have modified the drawer lookup procedure to take into account if the target type is a generic type, and if so, use its generic definition instead of the target type directly. I also changed the dictionary lookup to search for `checkType` which is assigned the current type's base type on every unsuccessful dictionary lookup.