### PR TITLE
fix: Ensure object picker is shown

### DIFF
--- a/Attributes/DisplayInspectorAttribute.cs
+++ b/Attributes/DisplayInspectorAttribute.cs
@@ -67,6 +67,7 @@ namespace MyBox.Internal
 					_foldout.Value = EditorGUI.Foldout(foldRect, _foldout.Value, label, true);
 					var fieldRect = new Rect(position);
 					fieldRect.x += EditorGUIUtility.labelWidth;
+					fieldRect.width -= EditorGUIUtility.labelWidth;
 					EditorGUI.PropertyField(fieldRect, property, GUIContent.none);
 					if (GUI.changed) property.serializedObject.ApplyModifiedProperties();
 


### PR DESCRIPTION
#### Before

The object picker is missing.

<img width="434" height="361" alt="2025-10-02 21 53 47" src="https://github.com/user-attachments/assets/6583027f-66fa-4887-852b-c7a44c610179" />

#### After

<img width="430" height="261" alt="2025-10-02 21 54 14" src="https://github.com/user-attachments/assets/9e07e6a7-63ad-4207-b056-6225e7b9e022" />
