### PR TITLE
feat(Attributes): Don't enforce Odin inspector

### DIFF
--- a/Attributes/ReadOnlyAttribute.cs
+++ b/Attributes/ReadOnlyAttribute.cs
@@ -1,5 +1,4 @@
-﻿#if !ODIN_INSPECTOR
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace MyBox
 {
@@ -72,5 +71,4 @@ namespace MyBox.Internal
         }
     }
 }
-#endif
 #endif


### PR DESCRIPTION
I think opening this kind of PR is a bit unusual. I’m currently using both Odin and MyBox, and I sometimes switch between them by simply changing the namespace. However, the preprocessor `#if ODIN_INSPECTOR` prevents that from working smoothly.

```cs
[MyBox.ReadOnly(...)]  // Missing due to the preprocessor declaration.

// to

[Odin.ReadOnly(...)]
```

I understand the author is trying to make it compatible with Odin, but I think it might be better to simply let users decide which one they want to use.