### PR TITLE
Implemented a Generic Bucket sorting alorithm

### DIFF
--- a/Extensions/MyCollections.cs
+++ b/Extensions/MyCollections.cs
@@ -299,6 +299,27 @@ namespace MyBox
 		}
 
 		/// <summary>
+		/// Creates a Bucket collection (Dictionary with List values) from a collection 
+		/// of values and a function that selects the key for each value.
+		/// </summary>
+		public static Dictionary<TKey, TArg> ConvertToBucket<TKey, TValue, TArg>( this IEnumerable<TValue> source, 
+		Func<TValue, TKey> GetKeyFromValue) where TArg : IList<TValue> {
+			
+			Dictionary<TKey, TArg> result = new Dictionary<TKey, TArg>(source.Count());
+			foreach(TValue value in source) {
+				TKey key = GetKeyFromValue(value);
+				if(result.TryGetValue(key, out TArg arg)) {
+					arg.Add(value);
+				} else {
+					TArg newArg = (TArg)Activator.CreateInstance(typeof(TArg));
+					newArg.Add(value);
+					result[key] = newArg;
+				}
+			}
+			return result;
+		}
+
+		/// <summary>
 		/// Performs an action on each element of a collection.
 		/// </summary>
 		public static IEnumerable<T> ForEach<T>(this IEnumerable<T> source, Action<T> action)


### PR DESCRIPTION
Adds a method to convert a collection to a bucket dictionary.
Allows user to define storage type, and algorithm for creating dictionary keys.

Issues: 

Generic Usage Cannot be inferred from type arguments.
Buckets are created from adding to collection, highly inefficient for list types